### PR TITLE
環境変数の統一とMakefileの改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MAKEFLAGS += --silent
 .PHONY: help setup start build-lambda deploy-local destroy-local clean check-localstack-ready stop
 
 # デフォルトターゲット
@@ -19,11 +20,11 @@ setup: ## 初期セットアップを実行
 # 開発環境起動（ビルド・デプロイ含む）
 start: ## 開発環境を起動・デプロイ
 	@echo "🚀 開発環境を起動中..."
-	@export $(cat .env.local | grep -v '^#' | xargs) && \
+	@export $$(cat .env.local | grep -v '^#' | xargs) && \
 	cd infrastructure && docker compose up -d
-	$(MAKE) wait-for-localstack
-	$(MAKE) build-lambda
-	$(MAKE) deploy-local
+	@$(MAKE) wait-for-localstack
+	@$(MAKE) build-lambda
+	@$(MAKE) deploy-local
 	@echo "✅ 開発環境の起動が完了しました"
 
 # LocalStack環境のセットアップ

--- a/env.local.sample
+++ b/env.local.sample
@@ -3,7 +3,7 @@
 
 # 🔑 必須設定 (Secrets Managerに保存)
 # 以下の値はTerraform経由でSecrets Managerに設定されます
-GEMINI_API_KEY_VALUE=your_gemini_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
 SLACK_ERROR_WEBHOOK_URL=
 SLACK_SUCCESS_WEBHOOK_URL=
 

--- a/env.production.sample
+++ b/env.production.sample
@@ -7,7 +7,7 @@
 # Google Gemini API Key
 # Google AI Studio (https://aistudio.google.com/app/apikey) で取得
 # このキーはTerraform経由でSecrets Managerに保存されます
-GEMINI_API_KEY_VALUE=your_gemini_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
 
 # API Gateway認証キー（セキュアなランダム文字列を生成）
 # 例: openssl rand -base64 32

--- a/infrastructure/environments/local/.env.tfvars.sample
+++ b/infrastructure/environments/local/.env.tfvars.sample
@@ -6,4 +6,4 @@ slack_error_webhook_url = ""
 slack_success_webhook_url = ""
 
 # Gemini API Key (stored in Secrets Manager)
-gemini_api_key_value = ""
+GEMINI_API_KEY = ""

--- a/infrastructure/environments/local/main.tf
+++ b/infrastructure/environments/local/main.tf
@@ -38,7 +38,7 @@ resource "aws_secretsmanager_secret" "app_secrets" {
 resource "aws_secretsmanager_secret_version" "app_secrets" {
   secret_id     = aws_secretsmanager_secret.app_secrets.id
   secret_string = jsonencode({
-    GEMINI_API_KEY             = var.gemini_api_key_value
+    GEMINI_API_KEY             = var.gemini_api_key
     SLACK_ERROR_WEBHOOK_URL    = var.slack_error_webhook_url
     SLACK_SUCCESS_WEBHOOK_URL  = var.slack_success_webhook_url
   })

--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -46,7 +46,7 @@ variable "gemini_api_key_secret_name" {
   default     = "minutes-analyzer/gemini-api-key"
 }
 
-variable "gemini_api_key_value" {
+variable "gemini_api_key" {
   description = "The value of the Gemini API key (for local/dev only)"
   type        = string
   sensitive   = true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -231,7 +231,7 @@ setup_terraform_vars() {
     if [ -f ".env.local" ]; then
         (
             echo "# .env.localから自動生成されるTerraform変数ファイル"
-            echo "gemini_api_key_value=\"$(grep GEMINI_API_KEY_VALUE .env.local | cut -d '=' -f2-)\""
+            echo "GEMINI_API_KEY=\"$(grep GEMINI_API_KEY .env.local | cut -d '=' -f2-)\""
             echo "slack_error_webhook_url=\"$(grep SLACK_ERROR_WEBHOOK_URL .env.local | cut -d '=' -f2-)\""
         ) > infrastructure/environments/local/terraform.tfvars
         log_success "✅ infrastructure/environments/local/terraform.tfvars を作成しました"


### PR DESCRIPTION
- GEMINI_API_KEYの名称を統一し、関連するファイルを更新
- Makefile内のコマンド実行時に出力をサイレント化
- Terraform変数ファイルの生成スクリプトを修正し、環境変数の取得方法を更新