### PR TITLE
make start時に発生しているwarningが表示されないようにした

### DIFF
--- a/infrastructure/environments/local/main.tf
+++ b/infrastructure/environments/local/main.tf
@@ -156,7 +156,17 @@ resource "aws_api_gateway_deployment" "minutes_analyzer" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.minutes_analyzer_api.id
-  stage_name  = var.environment
+}
+
+resource "aws_api_gateway_stage" "minutes_analyzer" {
+  deployment_id = aws_api_gateway_deployment.minutes_analyzer.id
+  rest_api_id   = aws_api_gateway_rest_api.minutes_analyzer_api.id
+  stage_name    = var.environment
+
+  tags = {
+    Name        = "${var.project_name}-api-stage-${var.environment}"
+    Environment = var.environment
+  }
 }
 
 resource "aws_lambda_permission" "api_gw" {
@@ -182,7 +192,7 @@ resource "aws_api_gateway_usage_plan" "minutes_analyzer_plan" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.minutes_analyzer_api.id
-    stage  = aws_api_gateway_deployment.minutes_analyzer.stage_name
+    stage  = aws_api_gateway_stage.minutes_analyzer.stage_name
   }
 
   quota_settings {

--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -100,3 +100,9 @@ variable "common_tags" {
     ManagedBy   = "terraform"
   }
 }
+
+variable "GEMINI_API_KEY" {
+  description = "Gemini API key for AI processing"
+  type        = string
+  sensitive   = true
+}

--- a/infrastructure/environments/production/variables.tf
+++ b/infrastructure/environments/production/variables.tf
@@ -92,3 +92,9 @@ variable "common_tags" {
     ManagedBy   = "terraform"
   }
 }
+
+variable "GEMINI_API_KEY" {
+  description = "Gemini API key for AI processing"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
- 本番およびローカル環境のmain.tfからstage_nameの参照を削除
- GEMINI_API_KEY変数をローカルおよび本番環境のvariables.tfに追加し、機密情報として設定
- 不要な空行を削除し、コードの整形を実施