### PR TITLE
Notion連携機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ generate-tfvars: ## terraform.tfvarsを.env.localから生成
 	@if [ -f .env.local ]; then \
 		( \
 			echo "# .env.localから自動生成されるTerraform変数ファイル"; \
-			echo "GEMINI_API_KEY=\"$$(grep GEMINI_API_KEY .env.local | cut -d '=' -f2-)\""; \
+			echo "gemini_api_key=\"$$(grep GEMINI_API_KEY .env.local | cut -d '=' -f2-)\""; \
 			echo "slack_webhook_url=\"$$(grep SLACK_WEBHOOK_URL .env.local | cut -d '=' -f2-)\""; \
+			echo "notion_api_key=\"$$(grep NOTION_API_KEY .env.local | cut -d '=' -f2-)\""; \
+			echo "notion_database_id=\"$$(grep NOTION_DATABASE_ID .env.local | cut -d '=' -f2-)\""; \
+			echo "notion_task_database_id=\"$$(grep NOTION_TASK_DATABASE_ID .env.local | cut -d '=' -f2-)\""; \
 		) > infrastructure/environments/local/terraform.tfvars; \
 		echo "✅ terraform.tfvarsを生成しました"; \
 	else \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Google Meetの文字起こしを自動分析し、決定事項・アクション
 - 🤖 **AI分析**: Gemini 2.5 Flash APIによる議事録分析
 - 📋 **自動抽出**: 決定事項・アクション項目・懸念事項を自動識別
 - 📢 **Slack連携**: 分析結果のSlack通知
+- 📝 **Notion連携**: 議事録とTODOタスクの自動作成
 - 💰 **コスト効率**: 月間$2-4の低コスト運用（100回/日実行時）
 
 ## 🚀 クイックスタート
@@ -45,7 +46,10 @@ cp env.local.sample .env.local
 
 `.env.local`で以下の設定を必ず変更してください：
 - `GEMINI_API_KEY`: Gemini API キーを設定
-- `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URLを設定
+- `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URLを設定（オプション）
+- `NOTION_API_KEY`: Notion Integration トークンを設定（オプション）
+- `NOTION_DATABASE_ID`: 議事録用データベースIDを設定（オプション）
+- `NOTION_TASK_DATABASE_ID`: タスク管理用データベースIDを設定（オプション）
 
 ### 開発環境の起動
 
@@ -86,9 +90,11 @@ make clean                  # ローカル環境をクリーンアップ
 
 ### システム構成
 
-- **Google Apps Script**: Google Driveの監視・前処理・Slack配信
+- **Google Apps Script**: Google Driveの監視・前処理
 - **AWS Lambda (Ruby)**: Gemini 2.5 Flash APIを使用した議事録分析
 - **API Gateway**: RESTful API エンドポイント
+- **Slack Integration**: 分析結果の通知
+- **Notion Integration**: 議事録ページとタスクの自動作成
 - **LocalStack**: ローカル開発環境でのAWSサービスエミュレート
 
 詳細な設計については [docs/architecture.md](docs/architecture.md) を参照してください。
@@ -113,7 +119,18 @@ minutes-analyzer/
 
 ### 必須設定
 - `GEMINI_API_KEY`: Gemini 2.5 Flash APIキー（[Google AI Studio](https://makersuite.google.com/app/apikey)で取得）
+
+### オプション設定
 - `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URL（[Slack App](https://api.slack.com/apps)で取得）
+- `NOTION_API_KEY`: Notion Integration トークン（[Notion開発者ポータル](https://www.notion.so/my-integrations)で取得）
+- `NOTION_DATABASE_ID`: 議事録用データベースID
+- `NOTION_TASK_DATABASE_ID`: タスク管理用データベースID
+
+### Notion設定手順
+1. [Notion開発者ポータル](https://www.notion.so/my-integrations)でインテグレーションを作成
+2. 議事録用とタスク管理用のデータベースを作成
+3. データベースにインテグレーションを招待（編集権限付与）
+4. データベースIDをURLから取得して設定
 
 ## 📖 ドキュメント
 

--- a/docs/tasks/1st.md
+++ b/docs/tasks/1st.md
@@ -45,11 +45,10 @@
 - [x] ON/OFF切り替え機能実装（`NOTION_ENABLED`環境変数）
 
 #### 2.3 Notion連携機能実装
-- [ ] Notion API基本連携実装
-- [ ] 議事録ページ自動作成機能
-- [ ] TODO項目のタスクDB連携
-- [ ] デモ用Notionワークスペース準備
-- [ ] ON/OFF切り替え機能実装（`NOTION_ENABLED`環境変数）
+- [x] Notion API設定
+- [x] Notion API基本連携実装
+- [x] 議事録ページ自動作成機能
+- [x] TODO項目のタスクDB連携
 
 #### 2.4 エラーハンドリング最小実装
 - [ ] API呼び出し失敗時の基本対応

--- a/env.local.sample
+++ b/env.local.sample
@@ -6,6 +6,11 @@
 GEMINI_API_KEY=your_gemini_api_key_here
 SLACK_WEBHOOK_URL=
 
+# 📝 Notion連携設定 (オプション)
+NOTION_API_KEY=
+NOTION_DATABASE_ID=
+NOTION_TASK_DATABASE_ID=
+
 # 🔧 LocalStack設定
 LOCALSTACK_API_KEY=
 LOCALSTACK_VOLUME_DIR=./infrastructure/infrastructure/volume

--- a/infrastructure/environments/local/main.tf
+++ b/infrastructure/environments/local/main.tf
@@ -38,8 +38,11 @@ resource "aws_secretsmanager_secret" "app_secrets" {
 resource "aws_secretsmanager_secret_version" "app_secrets" {
   secret_id     = aws_secretsmanager_secret.app_secrets.id
   secret_string = jsonencode({
-    GEMINI_API_KEY      = var.gemini_api_key
-    SLACK_WEBHOOK_URL   = var.slack_webhook_url
+    GEMINI_API_KEY          = var.gemini_api_key
+    SLACK_WEBHOOK_URL       = var.slack_webhook_url
+    NOTION_API_KEY          = var.notion_api_key
+    NOTION_DATABASE_ID      = var.notion_database_id
+    NOTION_TASK_DATABASE_ID = var.notion_task_database_id
   })
 }
 

--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -84,8 +84,28 @@ variable "common_tags" {
   }
 }
 
-variable "GEMINI_API_KEY" {
+variable "gemini_api_key" {
   description = "Gemini API key for AI processing"
   type        = string
   sensitive   = true
 }
+
+variable "notion_api_key" {
+  description = "Notion API key for integration"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "notion_database_id" {
+  description = "Notion database ID for meeting minutes"
+  type        = string
+  default     = ""
+}
+
+variable "notion_task_database_id" {
+  description = "Notion database ID for tasks"
+  type        = string
+  default     = ""
+}
+

--- a/lambda/lib/notion_client.rb
+++ b/lambda/lib/notion_client.rb
@@ -1,0 +1,416 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'time'
+
+class NotionClient
+  NOTION_API_BASE_URL = 'https://api.notion.com/v1'
+  NOTION_VERSION = ENV['NOTION_API_VERSION'] || '2022-06-28'
+
+  def initialize(api_key, database_id, task_database_id, logger)
+    @api_key = api_key
+    @database_id = database_id
+    @task_database_id = task_database_id
+    @logger = logger
+  end
+
+  def create_meeting_page(summary)
+    @logger.info("Creating Notion page for meeting minutes")
+    
+    uri = URI("#{NOTION_API_BASE_URL}/pages")
+    
+    # 議事録ページのプロパティを構築
+    properties = build_meeting_properties(summary)
+    
+    # ページコンテンツを構築
+    children = build_page_content(summary)
+    
+    request_body = {
+      parent: { database_id: @database_id },
+      properties: properties,
+      children: children
+    }
+    
+    response = make_notion_request(uri, request_body)
+    
+    if response[:success]
+      page_id = response[:data]['id']
+      @logger.info("Successfully created Notion page: #{page_id}")
+      
+      # TODO項目をタスクDBに連携
+      task_results = nil
+      if summary[:todos] && !summary[:todos].empty? && @task_database_id && !@task_database_id.empty?
+        task_results = create_tasks_from_todos(summary[:todos], page_id)
+      end
+      
+      result = { success: true, page_id: page_id, url: response[:data]['url'] }
+      
+      # タスク作成結果を含める
+      if task_results
+        failed_tasks = task_results.select { |t| !t[:success] }
+        if !failed_tasks.empty?
+          result[:task_creation_failures] = failed_tasks
+        end
+      end
+      
+      result
+    else
+      @logger.error("Failed to create Notion page: #{response[:error]}")
+      { success: false, error: response[:error] }
+    end
+  end
+
+  private
+
+  def build_meeting_properties(summary)
+    properties = {
+      "タイトル" => {
+        title: [
+          {
+            text: {
+              content: summary[:title] || "議事録 #{Time.now.strftime('%Y-%m-%d %H:%M')}"
+            }
+          }
+        ]
+      },
+      "日付" => {
+        date: {
+          start: Time.now.iso8601
+        }
+      }
+    }
+    
+    # 参加者の設定
+    if summary[:participants] && !summary[:participants].empty?
+      properties["参加者"] = {
+        multi_select: summary[:participants].map { |p| { name: p } }
+      }
+    end
+    
+    # 決定事項の設定
+    if summary[:decisions] && !summary[:decisions].empty?
+      properties["決定事項"] = {
+        rich_text: [
+          {
+            text: {
+              content: summary[:decisions].join("\n")
+            }
+          }
+        ]
+      }
+    end
+    
+    # TODOの設定
+    if summary[:todos] && !summary[:todos].empty?
+      properties["TODO"] = {
+        rich_text: [
+          {
+            text: {
+              content: summary[:todos].map { |todo| "• #{todo[:task]}" }.join("\n")
+            }
+          }
+        ]
+      }
+    end
+    
+    # スコアの設定
+    if summary[:score]
+      properties["スコア"] = {
+        number: summary[:score]
+      }
+    end
+    
+    properties
+  end
+
+  def build_page_content(summary)
+    content = []
+    
+    # ヘッダー
+    content << build_header
+    
+    # 各セクションを追加
+    content.concat(build_decisions_section(summary[:decisions])) if summary[:decisions] && !summary[:decisions].empty?
+    content.concat(build_todos_section(summary[:todos])) if summary[:todos] && !summary[:todos].empty?
+    content.concat(build_warnings_section(summary[:warnings])) if summary[:warnings] && !summary[:warnings].empty?
+    content.concat(build_emotion_section(summary[:emotion_analysis])) if summary[:emotion_analysis]
+    content.concat(build_efficiency_section(summary[:efficiency_advice])) if summary[:efficiency_advice]
+    
+    content
+  end
+
+  def build_header
+    {
+      type: "heading_1",
+      heading_1: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "議事録サマリー" }
+          }
+        ]
+      }
+    }
+  end
+
+  def build_decisions_section(decisions)
+    section = []
+    section << {
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "📌 決定事項" }
+          }
+        ]
+      }
+    }
+    
+    decisions.each do |decision|
+      section << {
+        type: "bulleted_list_item",
+        bulleted_list_item: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: decision }
+            }
+          ]
+        }
+      }
+    end
+    
+    section
+  end
+
+  def build_todos_section(todos)
+    section = []
+    section << {
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "✅ TODO項目" }
+          }
+        ]
+      }
+    }
+    
+    todos.each do |todo|
+      todo_text = todo[:task]
+      todo_text += " (担当: #{todo[:assignee]})" if todo[:assignee]
+      todo_text += " (期限: #{todo[:due_date]})" if todo[:due_date]
+      
+      section << {
+        type: "to_do",
+        to_do: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: todo_text }
+            }
+          ],
+          checked: false
+        }
+      }
+    end
+    
+    section
+  end
+
+  def build_warnings_section(warnings)
+    section = []
+    section << {
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "⚠️ 注意点" }
+          }
+        ]
+      }
+    }
+    
+    warnings.each do |warning|
+      section << {
+        type: "bulleted_list_item",
+        bulleted_list_item: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: warning }
+            }
+          ]
+        }
+      }
+    end
+    
+    section
+  end
+
+  def build_emotion_section(emotion_analysis)
+    section = []
+    section << {
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "😊 会議の雰囲気" }
+          }
+        ]
+      }
+    }
+    
+    section << {
+      type: "paragraph",
+      paragraph: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: emotion_analysis }
+          }
+        ]
+      }
+    }
+    
+    section
+  end
+
+  def build_efficiency_section(efficiency_advice)
+    section = []
+    section << {
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "💡 効率改善アドバイス" }
+          }
+        ]
+      }
+    }
+    
+    section << {
+      type: "paragraph",
+      paragraph: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: efficiency_advice }
+          }
+        ]
+      }
+    }
+    
+    section
+  end
+
+  def create_tasks_from_todos(todos, meeting_page_id)
+    @logger.info("Creating tasks in task database")
+    
+    task_results = []
+    todos.each do |todo|
+      result = create_task(todo, meeting_page_id)
+      task_results << { task: todo[:task], success: result[:success], error: result[:error] }
+    end
+    
+    task_results
+  end
+
+  def create_task(todo, meeting_page_id)
+    uri = URI("#{NOTION_API_BASE_URL}/pages")
+    
+    properties = {
+      "タスク名" => {
+        title: [
+          {
+            text: {
+              content: todo[:task]
+            }
+          }
+        ]
+      },
+      "ステータス" => {
+        select: {
+          name: "未着手"
+        }
+      },
+      "関連議事録" => {
+        relation: [
+          {
+            id: meeting_page_id
+          }
+        ]
+      }
+    }
+    
+    # 担当者の設定（テキストフィールドとして設定）
+    if todo[:assignee]
+      properties["担当者"] = {
+        rich_text: [
+          {
+            text: {
+              content: todo[:assignee]
+            }
+          }
+        ]
+      }
+    end
+    
+    # 期限の設定
+    if todo[:due_date]
+      properties["期限"] = {
+        date: {
+          start: todo[:due_date]
+        }
+      }
+    end
+    
+    request_body = {
+      parent: { database_id: @task_database_id },
+      properties: properties
+    }
+    
+    response = make_notion_request(uri, request_body)
+    
+    if response[:success]
+      @logger.info("Successfully created task: #{todo[:task]}")
+    else
+      @logger.error("Failed to create task: #{response[:error]}")
+    end
+    
+    response
+  end
+
+  def make_notion_request(uri, body)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    
+    request = Net::HTTP::Post.new(uri)
+    request['Authorization'] = "Bearer #{@api_key}"
+    request['Notion-Version'] = NOTION_VERSION
+    request['Content-Type'] = 'application/json'
+    request.body = JSON.generate(body)
+    
+    # Security: Never log the request headers to prevent API key exposure
+    @logger.debug("Making Notion API request to: #{uri}")
+    
+    begin
+      response = http.request(request)
+      
+      if response.code.to_i >= 200 && response.code.to_i < 300
+        { success: true, data: JSON.parse(response.body) }
+      else
+        error_details = JSON.parse(response.body) rescue response.body
+        { success: false, error: "HTTP #{response.code}: #{error_details}" }
+      end
+    rescue StandardError => e
+      @logger.error("Notion API request failed: #{e.message}")
+      { success: false, error: e.message }
+    end
+  end
+end

--- a/lambda/spec/lambda_handler_spec.rb
+++ b/lambda/spec/lambda_handler_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe LambdaHandler do
           expect(JSON.parse(result[:body])['summary']).to eq(summary)
           expect(JSON.parse(result[:body])['message']).to eq('Analysis complete.')
           expect(JSON.parse(result[:body])['integrations']['slack']).to eq('not_sent')
-          expect(JSON.parse(result[:body])['integrations']['notion']).to eq('enabled')
+          expect(JSON.parse(result[:body])['integrations']['notion']).to eq('not_created')
         end
 
         it 'Slack webhook URL未設定の警告をログに出力' do

--- a/lambda/spec/notion_client_spec.rb
+++ b/lambda/spec/notion_client_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+require_relative '../lib/notion_client'
+require 'webmock/rspec'
+
+RSpec.describe NotionClient do
+  let(:api_key) { 'test-notion-api-key' }
+  let(:database_id) { 'test-database-id' }
+  let(:task_database_id) { 'test-task-database-id' }
+  let(:logger) { Logger.new(nil) }
+  let(:client) { NotionClient.new(api_key, database_id, task_database_id, logger) }
+
+  describe '#create_meeting_page' do
+    let(:summary) do
+      {
+        title: '週次定例会議',
+        participants: ['田中', '佐藤', '鈴木'],
+        decisions: ['新機能のリリース日を来月15日に決定', '予算を20%増額することを承認'],
+        todos: [
+          { task: '仕様書の作成', assignee: '田中', due_date: '2024-02-01' },
+          { task: 'デザイン案の提出', assignee: '佐藤' }
+        ],
+        warnings: ['リソース不足の懸念あり'],
+        score: 85,
+        emotion_analysis: 'ポジティブで建設的な雰囲気',
+        efficiency_advice: '議題の事前共有により時間短縮可能'
+      }
+    end
+
+    context 'when page creation is successful' do
+      let(:page_id) { 'created-page-id' }
+      let(:page_url) { 'https://www.notion.so/created-page-id' }
+
+      before do
+        # Mock page creation
+        stub_request(:post, "https://api.notion.com/v1/pages")
+          .with(
+            headers: {
+              'Authorization' => "Bearer #{api_key}",
+              'Notion-Version' => '2022-06-28',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_return(
+            status: 200,
+            body: { id: page_id, url: page_url }.to_json
+          )
+
+        # Mock task creation
+        summary[:todos].each do |todo|
+          stub_request(:post, "https://api.notion.com/v1/pages")
+            .with(
+              headers: {
+                'Authorization' => "Bearer #{api_key}",
+                'Notion-Version' => '2022-06-28',
+                'Content-Type' => 'application/json'
+              },
+              body: hash_including(
+                parent: { database_id: task_database_id }
+              )
+            )
+            .to_return(
+              status: 200,
+              body: { id: "task-#{todo[:task]}", url: "https://www.notion.so/task" }.to_json
+            )
+        end
+      end
+
+      it 'creates a page and returns success result' do
+        result = client.create_meeting_page(summary)
+
+        expect(result).to eq({
+          success: true,
+          page_id: page_id,
+          url: page_url
+        })
+      end
+
+      it 'creates tasks for each todo item' do
+        client.create_meeting_page(summary)
+
+        # Verify task creation requests were made
+        expect(WebMock).to have_requested(:post, "https://api.notion.com/v1/pages")
+          .times(3) # 1 for page + 2 for tasks
+      end
+    end
+
+    context 'when page creation fails' do
+      before do
+        stub_request(:post, "https://api.notion.com/v1/pages")
+          .to_return(
+            status: 400,
+            body: { message: 'Invalid database ID' }.to_json
+          )
+      end
+
+      it 'returns failure result' do
+        result = client.create_meeting_page(summary)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include('400')
+      end
+    end
+
+    context 'when network error occurs' do
+      before do
+        stub_request(:post, "https://api.notion.com/v1/pages")
+          .to_raise(Net::ReadTimeout)
+      end
+
+      it 'returns failure result with error message' do
+        result = client.create_meeting_page(summary)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include('Net::ReadTimeout')
+      end
+    end
+  end
+
+  describe 'page content structure' do
+    let(:summary) do
+      {
+        title: 'テスト会議',
+        decisions: ['決定事項1'],
+        todos: [{ task: 'タスク1' }],
+        warnings: ['警告1'],
+        emotion_analysis: '良好',
+        efficiency_advice: 'アドバイス'
+      }
+    end
+
+    it 'includes all sections in the correct order' do
+      # Capture the request body
+      request_body = nil
+      stub_request(:post, "https://api.notion.com/v1/pages")
+        .with do |request|
+          body = JSON.parse(request.body)
+          # Only capture the main page creation request, not task creation
+          if body['parent'] && body['parent']['database_id'] == database_id
+            request_body = body
+          end
+          true
+        end
+        .to_return(status: 200, body: { id: 'test-id', url: 'test-url' }.to_json)
+
+      client.create_meeting_page(summary)
+
+      # Verify page structure
+      expect(request_body).not_to be_nil
+      expect(request_body).to have_key('children')
+      children = request_body['children']
+      expect(children).not_to be_empty
+      expect(children[0]['type']).to eq('heading_1')
+      expect(children[0]['heading_1']['rich_text'][0]['text']['content']).to eq('議事録サマリー')
+
+      # Check that all sections are present
+      section_headers = children
+        .select { |c| c['type'] == 'heading_2' }
+        .map { |c| c['heading_2']['rich_text'][0]['text']['content'] }
+
+      expect(section_headers).to include('📌 決定事項')
+      expect(section_headers).to include('✅ TODO項目')
+      expect(section_headers).to include('⚠️ 注意点')
+      expect(section_headers).to include('😊 会議の雰囲気')
+      expect(section_headers).to include('💡 効率改善アドバイス')
+    end
+  end
+end


### PR DESCRIPTION
- 環境設定ファイルにNotion APIキー、データベースID、タスクデータベースIDの設定を追加
- Makefileを更新し、Terraform変数ファイルにNotion関連の変数を追加
- README.mdにNotion連携の設定手順を追記
- Lambda関数でのNotionページ作成処理を実装し、Slack通知処理と統合
- Notionクライアントのテストケースを新規作成