### PR TITLE
feat: S3からプロンプトとスキーマを管理する機能を追加

### DIFF
--- a/lambda/Gemfile
+++ b/lambda/Gemfile
@@ -4,6 +4,7 @@ gem 'json'
 gem 'net-http'
 gem 'uri'
 gem 'aws-sdk-secretsmanager'
+gem 'aws-sdk-s3'
 
 group :test do
   gem 'rspec', '~> 3.12'

--- a/lambda/Gemfile.lock
+++ b/lambda/Gemfile.lock
@@ -13,6 +13,13 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+    aws-sdk-kms (1.110.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.196.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
     aws-sdk-secretsmanager (1.118.0)
       aws-sdk-core (~> 3, >= 3.228.0)
       aws-sigv4 (~> 1.5)
@@ -63,6 +70,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   aws-sdk-secretsmanager
   json
   net-http

--- a/lambda/lib/s3_client.rb
+++ b/lambda/lib/s3_client.rb
@@ -1,0 +1,66 @@
+require 'aws-sdk-s3'
+require 'json'
+
+class S3Client
+  def initialize(logger, environment = 'local')
+    @logger = logger
+    @environment = environment
+    @bucket_name = ENV.fetch('S3_PROMPTS_BUCKET', "minutes-analyzer-prompts-#{@environment}")
+    @s3_client = create_s3_client
+  end
+
+  def get_prompt
+    key = 'prompts/meeting_analysis_prompt.txt'
+    
+    @logger.info("Fetching prompt from S3: #{@bucket_name}/#{key}")
+    
+    begin
+      response = @s3_client.get_object(bucket: @bucket_name, key: key)
+      prompt = response.body.read
+      @logger.info("Successfully retrieved prompt (#{prompt.bytesize} bytes)")
+      prompt
+    rescue Aws::S3::Errors::ServiceError => e
+      @logger.error("Failed to fetch prompt from S3: #{e.message}")
+      raise "Unable to retrieve prompt from S3: #{e.message}"
+    end
+  end
+
+  def get_output_schema
+    key = 'schemas/output_schema.json'
+    
+    @logger.info("Fetching output schema from S3: #{@bucket_name}/#{key}")
+    
+    begin
+      response = @s3_client.get_object(bucket: @bucket_name, key: key)
+      schema_json = response.body.read
+      schema = JSON.parse(schema_json)
+      @logger.info("Successfully retrieved output schema")
+      schema
+    rescue Aws::S3::Errors::ServiceError => e
+      @logger.error("Failed to fetch output schema from S3: #{e.message}")
+      raise "Unable to retrieve output schema from S3: #{e.message}"
+    rescue JSON::ParserError => e
+      @logger.error("Invalid JSON in output schema: #{e.message}")
+      raise "Invalid output schema format: #{e.message}"
+    end
+  end
+
+  private
+
+  def create_s3_client
+    options = {
+      region: ENV.fetch('AWS_REGION', 'ap-northeast-1'),
+      logger: @logger,
+      log_level: :debug
+    }
+
+    # LocalStack endpoint configuration
+    if @environment == 'local'
+      options[:endpoint] = 'http://localstack:4566'
+      options[:force_path_style] = true
+      options[:credentials] = Aws::Credentials.new('test', 'test')
+    end
+
+    Aws::S3::Client.new(options)
+  end
+end

--- a/lambda/spec/s3_client_spec.rb
+++ b/lambda/spec/s3_client_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+require_relative '../lib/s3_client'
+
+RSpec.describe S3Client do
+  let(:logger) { double('logger') }
+  let(:environment) { 'local' }
+  let(:s3_client) { S3Client.new(logger, environment) }
+  let(:mock_s3) { double('Aws::S3::Client') }
+  let(:mock_response) { double('response') }
+  let(:mock_body) { double('body') }
+
+  before do
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:error)
+    allow(logger).to receive(:debug)
+    allow(Aws::S3::Client).to receive(:new).and_return(mock_s3)
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('S3_PROMPTS_BUCKET', anything).and_return('minutes-analyzer-prompts-local')
+  end
+
+  describe '#get_prompt' do
+    let(:prompt_content) { "Test prompt content" }
+
+    context 'when successful' do
+      before do
+        allow(mock_s3).to receive(:get_object).and_return(mock_response)
+        allow(mock_response).to receive(:body).and_return(mock_body)
+        allow(mock_body).to receive(:read).and_return(prompt_content)
+      end
+
+      it 'returns the prompt content' do
+        result = s3_client.get_prompt
+        expect(result).to eq(prompt_content)
+      end
+
+      it 'requests from correct bucket and key' do
+        expect(mock_s3).to receive(:get_object).with(
+          bucket: 'minutes-analyzer-prompts-local',
+          key: 'prompts/meeting_analysis_prompt.txt'
+        )
+        s3_client.get_prompt
+      end
+
+      it 'logs success' do
+        expect(logger).to receive(:info).with('Fetching prompt from S3: minutes-analyzer-prompts-local/prompts/meeting_analysis_prompt.txt')
+        expect(logger).to receive(:info).with(/Successfully retrieved prompt \(\d+ bytes\)/)
+        s3_client.get_prompt
+      end
+    end
+
+    context 'when S3 error occurs' do
+      before do
+        allow(mock_s3).to receive(:get_object).and_raise(
+          Aws::S3::Errors::NoSuchKey.new(nil, 'The specified key does not exist.')
+        )
+      end
+
+      it 'logs error and raises exception' do
+        expect(logger).to receive(:error).with(/Failed to fetch prompt from S3/)
+        expect { s3_client.get_prompt }.to raise_error(/Unable to retrieve prompt from S3/)
+      end
+    end
+  end
+
+  describe '#get_output_schema' do
+    let(:schema_content) { '{"type": "object", "properties": {}}' }
+    let(:parsed_schema) { { "type" => "object", "properties" => {} } }
+
+    context 'when successful' do
+      before do
+        allow(mock_s3).to receive(:get_object).and_return(mock_response)
+        allow(mock_response).to receive(:body).and_return(mock_body)
+        allow(mock_body).to receive(:read).and_return(schema_content)
+      end
+
+      it 'returns parsed JSON schema' do
+        result = s3_client.get_output_schema
+        expect(result).to eq(parsed_schema)
+      end
+
+      it 'requests from correct bucket and key' do
+        expect(mock_s3).to receive(:get_object).with(
+          bucket: 'minutes-analyzer-prompts-local',
+          key: 'schemas/output_schema.json'
+        )
+        s3_client.get_output_schema
+      end
+
+      it 'logs success' do
+        expect(logger).to receive(:info).with('Fetching output schema from S3: minutes-analyzer-prompts-local/schemas/output_schema.json')
+        expect(logger).to receive(:info).with('Successfully retrieved output schema')
+        s3_client.get_output_schema
+      end
+    end
+
+    context 'when JSON parsing fails' do
+      before do
+        allow(mock_s3).to receive(:get_object).and_return(mock_response)
+        allow(mock_response).to receive(:body).and_return(mock_body)
+        allow(mock_body).to receive(:read).and_return('invalid json')
+      end
+
+      it 'logs error and raises exception' do
+        expect(logger).to receive(:error).with(/Invalid JSON in output schema/)
+        expect { s3_client.get_output_schema }.to raise_error(/Invalid output schema format/)
+      end
+    end
+  end
+
+  describe 'S3 client configuration' do
+    context 'for local environment' do
+      it 'configures LocalStack endpoint' do
+        expect(Aws::S3::Client).to receive(:new).with(
+          hash_including(
+            endpoint: 'http://localstack:4566',
+            force_path_style: true,
+            region: 'ap-northeast-1'
+          )
+        )
+        S3Client.new(logger, 'local')
+      end
+    end
+
+    context 'for production environment' do
+      it 'uses default AWS configuration' do
+        expect(Aws::S3::Client).to receive(:new) do |opts|
+          expect(opts).to include(region: 'ap-northeast-1')
+          expect(opts).not_to have_key(:endpoint)
+          mock_s3
+        end
+        S3Client.new(logger, 'production')
+      end
+    end
+    
+    context 'when S3_PROMPTS_BUCKET environment variable is set' do
+      let(:custom_bucket) { 'custom-prompts-bucket' }
+      
+      before do
+        allow(ENV).to receive(:fetch).with('S3_PROMPTS_BUCKET', anything).and_return(custom_bucket)
+      end
+      
+      it 'uses the custom bucket name from environment variable' do
+        new_client = S3Client.new(logger, environment)
+        expect(mock_s3).to receive(:get_object).with(
+          bucket: custom_bucket,
+          key: 'prompts/meeting_analysis_prompt.txt'
+        ).and_return(mock_response)
+        allow(mock_response).to receive(:body).and_return(mock_body)
+        allow(mock_body).to receive(:read).and_return('test')
+        new_client.get_prompt
+      end
+    end
+  end
+end

--- a/prompts/output_schema.json
+++ b/prompts/output_schema.json
@@ -1,0 +1,170 @@
+{
+  "type": "object",
+  "properties": {
+    "meeting_summary": {
+      "type": "object",
+      "properties": {
+        "date": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+        "title": {"type": "string"},
+        "duration_minutes": {"type": "number"},
+        "participants": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["date", "title", "duration_minutes", "participants"]
+    },
+    "decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "content": {"type": "string"},
+          "category": {
+            "type": "string",
+            "enum": ["pricing", "schedule", "policy", "other"]
+          },
+          "timestamp": {"type": "string", "pattern": "^\\d{2}:\\d{2}:\\d{2}$"},
+          "decided_by": {"type": "string"}
+        },
+        "required": ["content", "category", "timestamp", "decided_by"]
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "task": {"type": "string"},
+          "assignee": {"type": "string"},
+          "priority": {
+            "type": "string",
+            "enum": ["high", "medium", "low"]
+          },
+          "deadline": {"type": ["string", "null"]},
+          "deadline_formatted": {"type": "string"},
+          "suggested_steps": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "timestamp": {"type": "string", "pattern": "^\\d{2}:\\d{2}:\\d{2}$"},
+          "notion_task_id": {"type": ["string", "null"]}
+        },
+        "required": ["task", "assignee", "priority", "deadline_formatted", "suggested_steps", "timestamp"]
+      }
+    },
+    "actions_summary": {
+      "type": "object",
+      "properties": {
+        "total_count": {"type": "number"},
+        "with_deadline": {"type": "number"},
+        "without_deadline": {"type": "number"},
+        "high_priority_count": {"type": "number"}
+      },
+      "required": ["total_count", "with_deadline", "without_deadline", "high_priority_count"]
+    },
+    "health_assessment": {
+      "type": "object",
+      "properties": {
+        "overall_score": {"type": "number", "minimum": 0, "maximum": 100},
+        "contradictions": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "unresolved_issues": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "undefined_items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "task": {"type": "string"},
+              "missing": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            },
+            "required": ["task", "missing"]
+          }
+        }
+      },
+      "required": ["overall_score", "contradictions", "unresolved_issues", "undefined_items"]
+    },
+    "participation_analysis": {
+      "type": "object",
+      "properties": {
+        "balance_score": {"type": "number", "minimum": 0, "maximum": 100},
+        "speaker_stats": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "speaking_count": {"type": "number"},
+              "speaking_ratio": {"type": "string", "pattern": "^\\d+%$"}
+            },
+            "required": ["speaking_count", "speaking_ratio"]
+          }
+        },
+        "silent_participants": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["balance_score", "speaker_stats", "silent_participants"]
+    },
+    "time_efficiency": {
+      "type": "object",
+      "properties": {
+        "actual_duration": {"type": "string"},
+        "scheduled_duration": {"type": "string"},
+        "topic_durations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      },
+      "required": ["actual_duration", "scheduled_duration", "topic_durations"]
+    },
+    "atmosphere": {
+      "type": "object",
+      "properties": {
+        "overall_tone": {
+          "type": "string",
+          "enum": ["positive", "neutral", "negative"]
+        },
+        "evidence": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["overall_tone", "evidence"]
+    },
+    "improvement_suggestions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["participation", "time_management", "decision_making", "facilitation"]
+          },
+          "suggestion": {"type": "string"},
+          "expected_impact": {"type": "string"}
+        },
+        "required": ["category", "suggestion", "expected_impact"]
+      }
+    }
+  },
+  "required": [
+    "meeting_summary",
+    "decisions",
+    "actions",
+    "actions_summary",
+    "health_assessment",
+    "participation_analysis",
+    "time_efficiency",
+    "atmosphere",
+    "improvement_suggestions"
+  ]
+}


### PR DESCRIPTION
  -
  S3Clientクラスを新規作成し、プロンプトとスキーマの取得機能を実装
  - S3バケット名を環境変数(S3_PROMPTS_BUCKET)で設定可能に
  - aws-sdk-s3の依存関係を追加
  - プロンプト管理用の設定ファイルを追加