### PR TITLE
  feat: Google Drive APIクライアントを追加

### DIFF
--- a/lambda/Gemfile
+++ b/lambda/Gemfile
@@ -5,6 +5,8 @@ gem 'net-http'
 gem 'uri'
 gem 'aws-sdk-secretsmanager'
 gem 'aws-sdk-s3'
+gem 'google-apis-drive_v3'
+gem 'googleauth'
 
 group :test do
   gem 'rspec', '~> 3.12'

--- a/lambda/Gemfile.lock
+++ b/lambda/Gemfile.lock
@@ -30,15 +30,57 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    declarative (0.0.20)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    google-apis-core (0.18.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.3, < 3.a)
+      mini_mime (~> 1.0)
+      mutex_m
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+    google-apis-drive_v3 (0.68.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-cloud-env (2.3.1)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-logging-utils (0.2.0)
+    googleauth (1.14.0)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     hashdiff (1.2.0)
+    httpclient (2.9.0)
+      mutex_m
     jmespath (1.6.2)
     json (2.13.2)
+    jwt (2.10.2)
+      base64
     logger (1.7.0)
+    mini_mime (1.1.5)
+    multi_json (1.17.0)
+    mutex_m (0.3.0)
     net-http (0.6.0)
       uri
+    os (1.1.4)
     public_suffix (6.0.2)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
     rexml (3.4.1)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -53,12 +95,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
+    signet (0.20.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    trailblazer-option (0.1.2)
+    uber (0.1.0)
     uri (1.0.3)
     webmock (3.25.1)
       addressable (>= 2.8.0)
@@ -72,6 +121,8 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   aws-sdk-secretsmanager
+  google-apis-drive_v3
+  googleauth
   json
   net-http
   rspec (~> 3.12)

--- a/lambda/lib/google_drive_client.rb
+++ b/lambda/lib/google_drive_client.rb
@@ -1,0 +1,95 @@
+require 'google/apis/drive_v3'
+require 'googleauth'
+require 'json'
+
+# Google Drive APIクライアント
+# 非公開の議事録ファイルにアクセスするため、サービスアカウント認証を使用
+# 事前に議事録フォルダへサービスアカウントのメールアドレスを「閲覧者」として共有する必要あり
+class GoogleDriveClient
+  def initialize(credentials_json, logger)
+    @logger = logger
+    @credentials_json = credentials_json
+    @drive_service = nil
+  end
+
+  def get_file_content(file_id)
+    @logger.info("Fetching file content from Google Drive: #{file_id}")
+    
+    begin
+      # Initialize the Drive service if not already done
+      initialize_drive_service unless @drive_service
+      
+      # Get file metadata first
+      file = @drive_service.get_file(
+        file_id,
+        fields: 'id, name, size, mimeType'
+      )
+      
+      @logger.info("File info - Name: #{file.name}, Size: #{file.size}, Type: #{file.mime_type}")
+      
+      # Check if file is too large (e.g., > 100MB)
+      if file.size && file.size > 100_000_000
+        raise "File too large: #{file.size} bytes (max 100MB)"
+      end
+      
+      # Download file content
+      content = download_file_content(file_id)
+      
+      @logger.info("Successfully downloaded file content: #{content.length} characters")
+      content
+      
+    rescue Google::Apis::Error => e
+      @logger.error("Google Drive API error: #{e.message}")
+      raise "Failed to fetch file from Google Drive: #{e.message}"
+    rescue StandardError => e
+      @logger.error("Error fetching file: #{e.message}")
+      raise
+    end
+  end
+
+  private
+
+  def initialize_drive_service
+    @logger.info("Initializing Google Drive service")
+    
+    # Parse credentials JSON
+    credentials = JSON.parse(@credentials_json)
+    
+    # サービスアカウント認証の作成
+    # JSONキーにはprivate_keyとclient_email（Driveフォルダに共有するメールアドレス）が含まれる
+    authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: StringIO.new(@credentials_json),
+      scope: 'https://www.googleapis.com/auth/drive.readonly'
+    )
+    
+    # Initialize Drive service
+    @drive_service = Google::Apis::DriveV3::DriveService.new
+    @drive_service.authorization = authorizer
+    
+    @logger.info("Google Drive service initialized successfully")
+  end
+
+  def download_file_content(file_id)
+    # For text files, we can export as plain text
+    content = StringIO.new
+    
+    @drive_service.export_file(
+      file_id,
+      'text/plain',
+      download_dest: content
+    )
+    
+    content.string
+  rescue Google::Apis::ClientError => e
+    # If export fails, try direct download
+    @logger.warn("Export failed, trying direct download: #{e.message}")
+    
+    content = StringIO.new
+    @drive_service.get_file(
+      file_id,
+      download_dest: content
+    )
+    
+    content.string
+  end
+end

--- a/lambda/spec/google_drive_client_spec.rb
+++ b/lambda/spec/google_drive_client_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+require_relative '../lib/google_drive_client'
+require 'google/apis/drive_v3'
+
+RSpec.describe GoogleDriveClient do
+  let(:logger) { instance_double(Logger, info: nil, error: nil, warn: nil) }
+  let(:credentials_json) do
+    {
+      "type": "service_account",
+      "project_id": "test-project",
+      "private_key_id": "key-id",
+      "private_key": "-----BEGIN PRIVATE KEY-----\ntest_key\n-----END PRIVATE KEY-----",
+      "client_email": "test@test-project.iam.gserviceaccount.com",
+      "client_id": "123456789",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com"
+    }.to_json
+  end
+  let(:client) { described_class.new(credentials_json, logger) }
+
+  describe '#get_file_content' do
+    let(:file_id) { '1234567890abcdef' }
+    let(:mock_drive_service) { instance_double(Google::Apis::DriveV3::DriveService) }
+    let(:mock_file) do
+      Google::Apis::DriveV3::File.new(
+        id: file_id,
+        name: 'test_meeting.txt',
+        size: 1024,
+        mime_type: 'text/plain'
+      )
+    end
+
+    before do
+      allow(Google::Apis::DriveV3::DriveService).to receive(:new).and_return(mock_drive_service)
+      allow(mock_drive_service).to receive(:authorization=)
+      allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(double(apply!: nil))
+    end
+
+    context 'when file is successfully retrieved' do
+      let(:file_content) { "2025年1月15日\n\n新機能リリース進捗確認ミーティング\n..." }
+
+      before do
+        allow(mock_drive_service).to receive(:get_file)
+          .with(file_id, fields: 'id, name, size, mimeType')
+          .and_return(mock_file)
+        
+        # Mock export_file for text/plain
+        allow(mock_drive_service).to receive(:export_file) do |id, mime_type, options|
+          options[:download_dest].write(file_content)
+        end
+      end
+
+      it 'returns the file content' do
+        result = client.get_file_content(file_id)
+        expect(result).to eq(file_content)
+      end
+
+      it 'logs file information' do
+        expect(logger).to receive(:info).with("Fetching file content from Google Drive: #{file_id}")
+        expect(logger).to receive(:info).with(/File info - Name: test_meeting.txt/)
+        expect(logger).to receive(:info).with(/Successfully downloaded file content/)
+        
+        client.get_file_content(file_id)
+      end
+    end
+
+    context 'when file is too large' do
+      before do
+        large_file = Google::Apis::DriveV3::File.new(
+          id: file_id,
+          name: 'large_file.txt',
+          size: 150_000_000,  # 150MB
+          mime_type: 'text/plain'
+        )
+        
+        allow(mock_drive_service).to receive(:get_file)
+          .with(file_id, fields: 'id, name, size, mimeType')
+          .and_return(large_file)
+      end
+
+      it 'raises an error' do
+        expect { client.get_file_content(file_id) }.to raise_error(/File too large/)
+      end
+    end
+
+    context 'when export fails and falls back to direct download' do
+      let(:file_content) { "Meeting transcript content" }
+
+      before do
+        allow(mock_drive_service).to receive(:get_file)
+          .with(file_id, fields: 'id, name, size, mimeType')
+          .and_return(mock_file)
+        
+        # Mock export_file to fail
+        allow(mock_drive_service).to receive(:export_file)
+          .and_raise(Google::Apis::ClientError.new("Export not supported"))
+        
+        # Mock direct download
+        allow(mock_drive_service).to receive(:get_file) do |id, options|
+          if options[:download_dest]
+            options[:download_dest].write(file_content)
+          else
+            mock_file
+          end
+        end
+      end
+
+      it 'falls back to direct download and returns content' do
+        expect(logger).to receive(:warn).with(/Export failed, trying direct download/)
+        
+        result = client.get_file_content(file_id)
+        expect(result).to eq(file_content)
+      end
+    end
+
+    context 'when Google Drive API returns an error' do
+      before do
+        allow(mock_drive_service).to receive(:get_file)
+          .and_raise(Google::Apis::AuthorizationError.new("Unauthorized"))
+      end
+
+      it 'raises an error with details' do
+        expect { client.get_file_content(file_id) }.to raise_error(/Failed to fetch file from Google Drive/)
+      end
+
+      it 'logs the error' do
+        expect(logger).to receive(:error).with(/Google Drive API error/)
+        
+        expect { client.get_file_content(file_id) }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
  - google-apis-drive_v3とgoogleauthのgemを追加
  - GoogleDriveClientクラスを実装
    - サービスアカウント認証対応
    - ファイルダウンロード機能
    - エラーハンドリング
  - テストを追加