### PR TITLE
feat: Google Service Accountの取り扱いを改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ yarn-error.log*
 *.p12
 *.key
 *.crt
+# Google Service Account認証情報
+# Makefileのgenerate-tfvarsタスクで.env.localから生成される
+# Terraformがfile()関数で読み込むため、リポジトリには含めない
+google_service_account.json
+*_service_account.json
 
 # Cache
 infrastructure/infrastructure/volume/cache/*

--- a/docs/google-drive-api-setup.md
+++ b/docs/google-drive-api-setup.md
@@ -53,28 +53,19 @@ IAMを活用することで、個別のフォルダ共有は不要になり、�
    - **Storage オブジェクト閲覧者**
 5. 「保存」をクリック
 
-### 6. サービスアカウントキーのBASE64エンコード
+### 6. サービスアカウントキーを環境変数に設定
 
-ダウンロードしたJSONファイルを環境変数で使用するため、BASE64エンコードします：
+ダウンロードしたサービスアカウントキー（JSONファイル）の内容全体をコピーし、プロジェクトルートにある`.env.local`ファイルの`GOOGLE_SERVICE_ACCOUNT_JSON`の値として貼り付けます。
+
+**重要:** JSONを貼り付ける際は、改行も含めてそのまま1行で貼り付けてください。以下のコマンドを使用すると便利です。
 
 ```bash
-# Linux/Unix
-cat ~/Downloads/your-service-account-key.json | base64
-
-# macOS（改行なしで出力）
-cat ~/Downloads/your-service-account-key.json | base64 -b 0
-
-# Windows (PowerShell)
-[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content ~/Downloads/your-service-account-key.json -Raw)))
+cat your-service-account-key.json | jq -c . | pbcopy
 ```
 
-### 7. 環境変数に設定
+これにより、整形されたJSONが1行でクリップボードにコピーされます。
 
-1. プロジェクトルートの`.env.local`ファイルを編集
-2. 以下の行を見つけて、BASE64エンコードした文字列を設定：
-   ```
-   GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=<ここに長いBASE64文字列を貼り付け>
-   ```
+
 
 ## セキュリティのベストプラクティス
 
@@ -98,7 +89,7 @@ cat ~/Downloads/your-service-account-key.json | base64 -b 0
 
 ### 認証エラーが発生する場合
 
-1. JSONキーが正しくBASE64エンコードされているか確認
+1. `GOOGLE_SERVICE_ACCOUNT_JSON`に正しいJSONが設定されているか確認
 2. 環境変数が正しく設定されているか確認
 3. サービスアカウントが有効か確認
 

--- a/env.local.sample
+++ b/env.local.sample
@@ -6,10 +6,9 @@
 GEMINI_API_KEY=your_gemini_api_key_here
 
 # 🔐 Google Drive API設定 (必須)
-# 非公開ファイルへのアクセスにはサービスアカウント認証が必要
-# BASE64エンコードする理由: JSONの改行を環境変数で扱いやすくするため
-# 設定方法: cat service-account-key.json | base64
-GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=
+# サービスアカウントのJSONキーをそのまま貼り付けてください（改行も含めて1行で）。
+# 例: GOOGLE_SERVICE_ACCOUNT_JSON={"type": "service_account", ...}
+GOOGLE_SERVICE_ACCOUNT_JSON=
 
 # 💬 Slack通知設定 (オプション)
 SLACK_WEBHOOK_URL=

--- a/infrastructure/environments/local/main.tf
+++ b/infrastructure/environments/local/main.tf
@@ -40,10 +40,13 @@ resource "aws_secretsmanager_secret" "app_secrets" {
 }
 
 resource "aws_secretsmanager_secret_version" "app_secrets" {
-  secret_id     = aws_secretsmanager_secret.app_secrets.id
+  secret_id = aws_secretsmanager_secret.app_secrets.id
   secret_string = jsonencode({
-    GEMINI_API_KEY              = var.gemini_api_key
-    GOOGLE_SERVICE_ACCOUNT_JSON = var.google_service_account_json
+    GEMINI_API_KEY = var.gemini_api_key
+    # Google Service Account JSONはファイルから読み込む
+    # file()関数を使用することで、JSONの改行やエスケープを正しく処理
+    # ファイルが存在しない場合は空文字列を設定（オプショナル対応）
+    GOOGLE_SERVICE_ACCOUNT_JSON = fileexists(var.google_service_account_json_path) ? file(var.google_service_account_json_path) : ""
     SLACK_WEBHOOK_URL           = var.slack_webhook_url
     NOTION_API_KEY              = var.notion_api_key
     NOTION_DATABASE_ID          = var.notion_database_id

--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -104,10 +104,9 @@ variable "notion_task_database_id" {
   default     = ""
 }
 
-variable "google_service_account_json" {
-  description = "Google service account JSON for Drive API access"
+variable "google_service_account_json_path" {
+  description = "Path to Google service account JSON file for Drive API access"
   type        = string
-  sensitive   = true
-  default     = ""
+  default     = "./google_service_account.json"
 }
 


### PR DESCRIPTION
- Google Service AccountのJSONファイルを直接扱う方式に変更
- .env.localにサービスアカウントのJSONを直接設定する方法を更新
- MakefileでのTerraform変数生成時にJSONファイルを読み込む処理を追加
- ドキュメントを更新し、設定手順を明確化