### PR TITLE
feat: 環境設定・インフラストラクチャ

### DIFF
--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -60,7 +60,36 @@ variable "slack_webhook_url" {
   sensitive   = true
 }
 
+variable "slack_bot_token" {
+  description = "Slack Bot User OAuth Token"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
 
+variable "google_service_account_json_path" {
+  description = "Path to Google service account JSON file"
+  type        = string
+  default     = ""
+}
+
+variable "google_calendar_enabled" {
+  description = "Enable Google Calendar integration"
+  type        = bool
+  default     = false
+}
+
+variable "user_mapping_enabled" {
+  description = "Enable user mapping for Slack and Notion"
+  type        = bool
+  default     = false
+}
+
+variable "cache_ttl" {
+  description = "Cache TTL in seconds"
+  type        = number
+  default     = 600
+}
 
 variable "log_level" {
   description = "Log level for the lambda function"


### PR DESCRIPTION
## 概要
Lambda関数の環境設定とインフラストラクチャを更新し、新機能に必要な設定を追加

## 変更内容
### Secrets Manager
- SLACK_BOT_TOKEN の追加
- GOOGLE_SERVICE_ACCOUNT_JSON の追加（ファイルから読み込み）

### Lambda環境変数
- GOOGLE_CALENDAR_ENABLED フラグ
- USER_MAPPING_ENABLED フラグ
- CACHE_TTL 設定（デフォルト: 600秒）

### IAM権限
- CloudWatchメトリクス送信権限の追加
- ログ書き込み権限の明示的な設定

### Terraform変数
- google_calendar_enabled
- user_mapping_enabled
- cache_ttl
- slack_bot_token
- google_service_account_json_path

## テスト項目
- [ ] Secrets Managerからのシークレット取得
- [ ] 環境変数の正しい設定
- [ ] CloudWatchメトリクスの送信
- [ ] IAM権限の動作確認