### PR TITLE
docs: ドキュメント整備とSlack/統合テストガイドの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,16 @@
 - 必要なAPIキー・サービスアカウント
 
 ## 環境変数の設定
-- 必須: GEMINI_API_KEY
-- オプション:
-  - SLACK_WEBHOOK_URL
-  - NOTION_API_KEY,
-  - NOTION_DATABASE_ID
-  - NOTION_TASK_DATABASE_ID
+### 必須設定
+- `GEMINI_API_KEY`: Gemini API キー
+- `GOOGLE_SERVICE_ACCOUNT_JSON`: Google サービスアカウント認証情報
+
+### オプション設定
+- `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token（xoxb-で始まる）
+- `SLACK_CHANNEL_ID`: Slack 送信先チャンネルID（例: C1234567890）
+- `NOTION_API_KEY`: Notion Integration トークン
+- `NOTION_DATABASE_ID`: 議事録用データベースID
+- `NOTION_TASK_DATABASE_ID`: タスク管理用データベースID
 
 ## 利用可能なMakefileコマンド
   - make help - ヘルプ表示

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ cp env.local.sample .env.local
 - `GEMINI_API_KEY`: Gemini API キー（[Google AI Studio](https://makersuite.google.com/app/apikey)で取得）
 - `GOOGLE_SERVICE_ACCOUNT_JSON`: Google サービスアカウント認証情報
 
-- `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URL
+**オプション設定**
+- `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token（[設定ガイド](docs/slack-integration-guide.md)参照）
+- `SLACK_CHANNEL_ID`: Slack 送信先チャンネルID（例: C1234567890）
 - `NOTION_API_KEY`: Notion Integration トークン
 - `NOTION_DATABASE_ID`: 議事録用データベースID
 - `NOTION_TASK_DATABASE_ID`: タスク管理用データベースID
@@ -144,7 +146,8 @@ minutes-analyzer/
 - `GOOGLE_SERVICE_ACCOUNT_JSON`: Google Drive API用のサービスアカウント認証情報（JSON形式）
 
 ### オプション設定
-- `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URL（[Slack App](https://api.slack.com/apps)で取得）
+- `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token（[設定ガイド](docs/slack-integration-guide.md)参照）
+- `SLACK_CHANNEL_ID`: Slack 送信先チャンネルID（例: C1234567890）
 - `NOTION_API_KEY`: Notion Integration トークン（[Notion開発者ポータル](https://www.notion.so/my-integrations)で取得）
 - `NOTION_DATABASE_ID`: 議事録用データベースID
 - `NOTION_TASK_DATABASE_ID`: タスク管理用データベースID
@@ -169,6 +172,8 @@ minutes-analyzer/
 
 - [アーキテクチャ設計](docs/architecture.md)
 - [Google Drive API設定ガイド](docs/google-drive-api-setup.md)
+- [Slack Integration設定ガイド](docs/slack-integration-guide.md)
+- [統合テスト実施手順書](docs/integration-test-guide.md)
 
 ## 🧪 ヘルスチェック
 

--- a/docs/integration-test-guide.md
+++ b/docs/integration-test-guide.md
@@ -1,0 +1,231 @@
+# 統合テスト実施手順書
+
+## 概要
+本書は、議事録分析システムの統合テストを実施するための手順書です。LocalStack環境でのテストから本番環境でのテストまでを網羅しています。
+
+## 前提条件
+
+### 必要な環境
+- Docker および Docker Compose が起動していること
+- LocalStack が稼働していること
+- AWS CLI がインストールされていること
+- 必要な環境変数が `.env.local` に設定されていること
+
+### 必要な認証情報
+- Google Drive API のサービスアカウント認証情報
+- Gemini API キー
+- Slack Bot Token とChannel ID（オプション）
+- Notion API キーとDatabase ID（オプション）
+
+## テスト実施手順
+
+### 1. 環境のセットアップ
+
+```bash
+# 開発環境の起動（LocalStack、ビルド、デプロイを一括実行）
+make start
+```
+
+### 2. テストデータの準備
+
+#### テストペイロードファイル
+`test/sample-data/test_integration_payload.json` を使用してください。
+
+```json
+{
+  "body": "{\"file_id\": \"1gr4YjB-m98qSqa4739VOXgI5UZa1GBtvsur04bpG-rg\", \"file_name\": \"議事録テストファイル.txt\"}",
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}
+```
+
+**注意**: `file_id` は実際のGoogle Drive上のファイルIDに置き換えてください。
+
+### 3. Lambda関数の呼び出し
+
+#### LocalStack環境でのテスト
+
+```bash
+# 統合テストの実行
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+aws --endpoint-url=http://localhost:4566 --region=ap-northeast-1 \
+lambda invoke \
+--function-name minutes-analyzer-local \
+--payload fileb://test/sample-data/test_integration_payload.json \
+--cli-read-timeout 120 \
+integration_test_result.json
+
+# 実行結果の確認
+cat integration_test_result.json | jq '.'
+```
+
+#### 本番環境でのテスト（オプション）
+
+```bash
+# 本番環境へのデプロイ後
+aws lambda invoke \
+--function-name minutes-analyzer-production \
+--payload fileb://test/sample-data/test_integration_payload.json \
+--cli-read-timeout 120 \
+production_test_result.json
+```
+
+### 4. テスト結果の確認
+
+#### 成功時のレスポンス例
+
+```json
+{
+  "statusCode": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": {
+    "message": "Analysis complete.",
+    "analysis": {
+      "meeting_summary": {
+        "title": "会議タイトル",
+        "date": "YYYY-MM-DD",
+        "duration_minutes": 30,
+        "participants": ["参加者1", "参加者2"]
+      },
+      "decisions": [...],
+      "actions": [...],
+      "health_assessment": {...},
+      "improvement_suggestions": [...]
+    },
+    "integrations": {
+      "slack": "sent/not_sent",
+      "notion": "created/not_created"
+    }
+  }
+}
+```
+
+### 5. ログの確認
+
+#### CloudWatch Logs（LocalStack）での確認
+
+```bash
+# 最新のログストリームを確認
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+aws --endpoint-url=http://localhost:4566 --region=ap-northeast-1 \
+logs describe-log-streams \
+--log-group-name="/aws/lambda/minutes-analyzer-local" \
+--order-by LastEventTime --descending --limit 1
+
+# ログイベントの取得
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+aws --endpoint-url=http://localhost:4566 --region=ap-northeast-1 \
+logs get-log-events \
+--log-group-name="/aws/lambda/minutes-analyzer-local" \
+--log-stream-name="<取得したログストリーム名>"
+```
+
+## テスト項目チェックリスト
+
+### 基本機能（正常系）
+- [ ] Lambda関数が正常に起動する
+- [ ] Google Drive APIでファイルを取得できる
+- [ ] Gemini APIで議事録分析が実行される
+- [ ] 分析結果がJSON形式で返される
+
+### エラーケーステスト（異常系）
+- [ ] 無効なfile_idでのエラーハンドリング
+- [ ] Google Drive認証失敗時の適切なエラーメッセージ
+- [ ] Gemini API制限超過時のリトライ動作
+- [ ] Slack/Notion連携失敗時の部分的成功レスポンス
+- [ ] タイムアウト時の適切な処理
+
+### 分析結果の確認
+- [ ] 会議サマリーが抽出されている
+- [ ] 決定事項が正しく抽出されている
+- [ ] アクション項目が抽出されている
+- [ ] 健全性評価が含まれている
+- [ ] 改善提案が生成されている
+
+### 外部連携（設定時のみ）
+- [ ] Slack通知が送信される（SLACK_BOT_TOKEN設定時）
+- [ ] Notion ページが作成される（NOTION_API_KEY設定時）
+- [ ] エラー時も Lambda は200を返す（部分的成功）
+
+## トラブルシューティング
+
+### よくあるエラーと対処法
+
+#### 1. Google Drive API エラー
+```
+"error": "Google credentials missing"
+```
+**対処法**:
+- `.env.local` に `GOOGLE_SERVICE_ACCOUNT_JSON` が設定されているか確認
+- Secrets Manager に正しく同期されているか確認
+- サービスアカウントにファイルへのアクセス権限があるか確認
+
+#### 2. Gemini API エラー
+```
+"error": "API key is missing"
+```
+**対処法**:
+- `.env.local` に `GEMINI_API_KEY` が設定されているか確認
+- APIキーが有効か確認（Google AI Studioで確認）
+
+#### 3. Slack 通知エラー
+```
+"slack_notification": {"success": false, "error": "missing_scope"}
+```
+**対処法**:
+- Slack Bot Token に `chat:write` スコープがあるか確認
+- Channel ID が正しい形式（C で始まるID）か確認
+
+#### 4. Notion 連携エラー
+```
+"notion_result": {"success": false, "error": "undefined method '[]' for nil:NilClass"}
+```
+**対処法**:
+- Notion API キーが正しいか確認
+- Database ID が正しいか確認
+- Notion Integration がデータベースに招待されているか確認
+
+### デバッグ用コマンド
+
+```bash
+# Secrets Manager の内容確認
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+aws --endpoint-url=http://localhost:4566 --region=ap-northeast-1 \
+secretsmanager get-secret-value \
+--secret-id minutes-analyzer-secrets-local \
+--query SecretString --output text | jq '.'
+
+# Lambda 関数の設定確認
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+aws --endpoint-url=http://localhost:4566 --region=ap-northeast-1 \
+lambda get-function \
+--function-name minutes-analyzer-local
+```
+
+## 継続的な統合テスト
+
+### 日次テスト
+```bash
+# Makefile コマンドで簡単実行（今後実装予定）
+make integration-test
+```
+
+### CI/CD パイプラインでの実行
+GitHub Actions や他のCI/CDツールで、プルリクエスト時に自動実行することを推奨します。
+
+## 改善提案
+
+1. **テストデータの拡充**: 様々なパターンの議事録でテスト
+2. **自動化の強化**: テスト結果の自動検証スクリプトの作成
+3. **パフォーマンステスト**: 大規模な議事録での処理時間測定
+4. **エラーケーステスト**: 異常系のテストケース追加
+
+## 参考資料
+
+- [アーキテクチャ設計](architecture.md)
+- [Google Drive API設定ガイド](google-drive-api-setup.md)
+- [Notion API設定ガイド](notion-api-setup.md)
+- [README](../README.md)

--- a/docs/slack-integration-guide.md
+++ b/docs/slack-integration-guide.md
@@ -1,0 +1,164 @@
+# Slack Integration ガイド
+
+## 概要
+
+本ドキュメントは、議事録分析システムのSlack連携機能の設定方法と必要なOAuth Scopeについて説明します。
+
+## Slack App の設定手順
+
+### 1. Slack App の作成
+
+1. [Slack API](https://api.slack.com/apps) にアクセス
+2. 「Create New App」をクリック
+3. 「From scratch」を選択
+4. App名に「Minutes Analyzer」（または任意の名前）を入力
+5. ワークスペースを選択して「Create App」をクリック
+
+### 2. Bot Token の設定
+
+1. 左メニューから「OAuth & Permissions」を選択
+2. 「Scopes」セクションまでスクロール
+3. 「Bot Token Scopes」で必要なスコープを追加（下記参照）
+4. ページ上部の「Install to Workspace」をクリック
+5. 権限を確認して「Allow」をクリック
+6. 表示される「Bot User OAuth Token」（`xoxb-`で始まる）をコピー
+
+### 3. 環境変数の設定
+
+`.env.local` または `.env.production` に以下を設定：
+
+```bash
+SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxx-xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+SLACK_CHANNEL_ID=C1234567890  # 投稿先チャンネルのID
+```
+
+## 必要な OAuth Scopes
+
+議事録分析システムが正常に動作するために必要なSlack OAuth Scopeの一覧です。
+
+| OAuth Scope | 説明 | 使用目的 |
+|------------|------|----------|
+| `chat:write` | Send messages as @minutes-analyzer | 議事録分析結果をチャンネルにメインメッセージとして投稿 |
+| `chat:write.public` | Send messages to channels @minutes-analyzer isn't a member of | Botがメンバーでないパブリックチャンネルへの投稿を可能にする |
+| `users.profile:read` | View profile details about people in a workspace | ユーザープロフィール情報の取得（将来的な機能拡張用） |
+| `users:read` | View people in a workspace | ワークスペースのユーザー一覧取得（将来的な機能拡張用） |
+| `users:read.email` | View email addresses of people in a workspace | ユーザーのメールアドレス取得（将来的な機能拡張用） |
+
+### 必須スコープ
+
+現在のシステムで**必須**となるスコープ：
+- `chat:write` - 基本的なメッセージ送信機能
+- `chat:write.public` - パブリックチャンネルへの投稿（Botがメンバーでない場合）
+
+**重要**: 両方のスコープを設定することで、どのチャンネルにも柔軟に投稿できるようになります。
+
+### オプションスコープ
+
+将来の機能拡張に備えて設定されているスコープ：
+- `users.profile:read`
+- `users:read` 
+- `users:read.email`
+
+これらは現在のバージョンでは使用されていませんが、今後の機能追加（例：参加者の自動マッピング、メンション機能など）で使用予定です。
+
+## 投稿先チャンネルの設定
+
+### チャンネルIDの取得方法
+
+1. Slackでチャンネルを右クリック
+2. 「チャンネル詳細を表示」を選択
+3. 最下部の「チャンネルID」をコピー（`C`で始まる文字列）
+
+### プライベートチャンネルへの投稿
+
+プライベートチャンネルに投稿する場合は、以下の手順でBotを招待する必要があります：
+
+1. 対象のプライベートチャンネルに移動
+2. チャンネルで `/invite @minutes-analyzer` を実行
+3. または、チャンネル設定 → インテグレーション → アプリを追加
+
+## メッセージ形式
+
+### メインメッセージ
+
+議事録分析結果は以下の形式で投稿されます：
+
+```
+📝 [会議タイトル]
+━━━━━━━━━━━━━━━━━━━━━━━━
+📅 日付: YYYY-MM-DD
+⏱️ 所要時間: XX分
+👥 参加者: 参加者1, 参加者2, ...
+
+🎯 決定事項: X件
+📋 アクション: Y件
+
+🎯 主な決定事項
+1. 決定事項1
+2. 決定事項2
+...
+
+📋 アクション一覧
+1. 🔴 [高優先度] タスク1 - 担当者（期限）
+2. 🟡 [中優先度] タスク2 - 担当者（期限）
+...
+```
+
+### スレッド返信
+
+メインメッセージに対するスレッド返信として、以下の詳細情報が投稿されます：
+
+- 😊 会議の雰囲気
+- 💡 改善提案
+
+## トラブルシューティング
+
+### `missing_scope` エラー
+
+エラーメッセージ例：
+```json
+{
+  "error": "missing_scope",
+  "needed": "chat:write",
+  "provided": "users:read,users:read.email"
+}
+```
+
+**対処法：**
+1. Slack App管理画面で必要なスコープが追加されているか確認
+2. スコープ追加後、必ず「Reinstall to Workspace」を実行
+3. 新しいBot Tokenを取得して環境変数を更新
+
+### `channel_not_found` エラー
+
+**対処法：**
+1. チャンネルIDが正しいか確認（`#`を含めない）
+2. プライベートチャンネルの場合、Botが招待されているか確認
+3. チャンネルIDの形式を確認（`C`で始まる英数字）
+
+### `not_in_channel` エラー
+
+**対処法：**
+1. パブリックチャンネルの場合：`chat:write.public` スコープを追加
+2. プライベートチャンネルの場合：Botをチャンネルに招待
+
+## セキュリティ上の注意事項
+
+1. **Bot Token の管理**
+   - Bot Tokenは環境変数として管理し、コードに直接記載しない
+   - `.env.local` ファイルは `.gitignore` に含める
+   - 本番環境ではAWS Secrets Managerなどのシークレット管理サービスを使用
+
+2. **スコープの最小権限の原則**
+   - 必要最小限のスコープのみを要求
+   - 不要になったスコープは削除
+
+3. **チャンネル設定**
+   - 機密情報を含む議事録は適切なプライベートチャンネルに投稿
+   - チャンネルIDは環境変数として管理
+
+## 関連ドキュメント
+
+- [統合テスト実施手順書](integration-test-guide.md)
+- [アーキテクチャ設計](architecture.md)
+- [README](../README.md)


### PR DESCRIPTION
## 概要
プロジェクトドキュメントを更新し、Slack Bot Token対応と統合テストのための新しいガイドを追加

## 変更内容
### ドキュメント更新
- CLAUDE.md: 環境変数設定をWebhookからBot Token/Channel IDに更新
- README.md: Slack設定の説明を更新、新規ガイドへのリンク追加

### 新規ドキュメント追加
- docs/slack-integration-guide.md: Slack Bot設定の詳細手順とOAuth Scopeの説明
- docs/integration-test-guide.md: LocalStack環境での統合テスト実施手順

## 影響範囲
- ドキュメントのみの変更で、実装への影響なし
- 新規ユーザーのセットアップ体験の改善