### PR TITLE
feat: 環境変数設定をSlack Web API対応に更新

### DIFF
--- a/env.local.sample
+++ b/env.local.sample
@@ -11,8 +11,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 GOOGLE_SERVICE_ACCOUNT_JSON=
 
 # 💬 Slack通知設定 (オプション)
-SLACK_WEBHOOK_URL=
+# SLACK_CHANNEL_IDはSlackワークスペースのチャンネルIDを指定（例: C1234567890）
 SLACK_BOT_TOKEN=
+SLACK_CHANNEL_ID=
 
 # 📝 Notion連携設定 (オプション)
 NOTION_API_KEY=

--- a/env.production.sample
+++ b/env.production.sample
@@ -12,10 +12,12 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # ===== Slack通知設定 =====
 
-# Slack通知用Webhook URL
-# Slack App作成 > Incoming Webhooks で取得
-SLACK_WEBHOOK_URL=
+# Slack Bot Token (xoxb-で始まるトークン)
+# Slack App作成 > OAuth & Permissions > Bot User OAuth Tokenで取得
 SLACK_BOT_TOKEN=
+# 送信先チャンネルID（例: C1234567890）
+# チャンネルを右クリック > View channel details > Channel IDで確認
+SLACK_CHANNEL_ID=
 
 # ===== AWS設定 =====
 
@@ -32,16 +34,16 @@ AWS_REGION=ap-northeast-1
 # openssl rand -base64 32
 # または Python: import secrets; print(secrets.token_urlsafe(32))
 
-# Slack Webhook URL取得手順:
+# Slack Bot Token取得手順:
 # 1. https://api.slack.com/apps にアクセス
 # 2. Create New App > From scratch
-# 3. Incoming Webhooks を有効化
-# 4. Add New Webhook to Workspace
-# 5. 対象チャンネル（#alerts, #meeting-analysis）を選択
-# 6. 生成されたWebhook URLをコピー
+# 3. OAuth & Permissions > Scopes で chat:write, chat:write.public を追加
+# 4. Install to Workspace
+# 5. Bot User OAuth Tokenをコピー
+# 6. チャンネルにBotを招待
 
 # セキュリティベストプラクティス:
 # - 本ファイルは必ず .gitignore に追加
 # - APIキーは定期的にローテーション
 # - 本番環境では強力なAPIキーを使用
-# - Slack Webhookはチャンネル権限を適切に設定
+# - Slack Botはチャンネル権限を適切に設定

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -229,12 +229,9 @@ setup_terraform_vars() {
     log_info "Terraform変数ファイルを作成中..."
     cd "$PROJECT_ROOT"
     if [ -f ".env.local" ]; then
-        (
-            echo "# .env.localから自動生成されるTerraform変数ファイル"
-            echo "GEMINI_API_KEY=\"$(grep GEMINI_API_KEY .env.local | cut -d '=' -f2-)\""
-            echo "slack_webhook_url=\"$(grep SLACK_WEBHOOK_URL .env.local | cut -d '=' -f2-)\""
-        ) > infrastructure/environments/local/terraform.tfvars
-        log_success "✅ infrastructure/environments/local/terraform.tfvars を作成しました"
+        log_warning "⚠️ .env.localが見つかりました。"
+        log_info "Terraform変数ファイルを生成するには 'make generate-tfvars' を実行してください。"
+        log_info "このコマンドはMakefile内で安全に環境変数を処理します。"
     else
         log_warning "⚠️ .env.local が見つかりません。terraform.tfvars は作成されませんでした。"
     fi


### PR DESCRIPTION
## 概要
Slack Webhook URLからBot Token/Channel IDベースの設定に移行

## 変更内容
### 環境変数の更新
- env.local.sample: SLACK_BOT_TOKEN/SLACK_CHANNEL_IDを追加
- env.production.sample: Bot Token取得手順を更新
- scripts/setup.sh: Terraform変数生成の簡素化

### 設定の移行
- SLACK_WEBHOOK_URL → SLACK_BOT_TOKEN + SLACK_CHANNEL_ID
- より柔軟なSlack連携が可能に

## 影響範囲
- 新規セットアップ時の環境変数設定
- 既存環境は.envファイルの更新が必要