### PR TITLE
feat: TerraformインフラをSlack Web API対応に更新

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,17 @@ generate-tfvars: ## terraform.tfvarsを.env.localから生成
 		( \
 			echo "# .env.localから自動生成されるTerraform変数ファイル"; \
 			echo "gemini_api_key=\"$$(grep GEMINI_API_KEY .env.local | cut -d '=' -f2-)\""; \
-			echo "slack_webhook_url=\"$$(grep SLACK_WEBHOOK_URL .env.local | cut -d '=' -f2-)\""; \
+			echo "slack_bot_token=\"$$(grep SLACK_BOT_TOKEN .env.local | cut -d '=' -f2-)\""; \
+			echo "slack_channel_id=\"$$(grep SLACK_CHANNEL_ID .env.local | cut -d '=' -f2-)\""; \
 			echo "notion_api_key=\"$$(grep NOTION_API_KEY .env.local | cut -d '=' -f2-)\""; \
 			echo "notion_database_id=\"$$(grep NOTION_DATABASE_ID .env.local | cut -d '=' -f2-)\""; \
 			echo "notion_task_database_id=\"$$(grep NOTION_TASK_DATABASE_ID .env.local | cut -d '=' -f2-)\""; \
 		) > infrastructure/environments/local/terraform.tfvars; \
 		if [ -n "$$(grep GOOGLE_SERVICE_ACCOUNT_JSON .env.local | cut -d '=' -f2-)" ]; then \
 			grep GOOGLE_SERVICE_ACCOUNT_JSON .env.local | cut -d '=' -f2- > infrastructure/environments/local/google_service_account.json; \
+			if ! grep -q "google_service_account_json_path" infrastructure/environments/local/terraform.tfvars; then \
+				echo "google_service_account_json_path=\"google_service_account.json\"" >> infrastructure/environments/local/terraform.tfvars; \
+			fi; \
 			echo "✅ google_service_account.jsonを生成しました"; \
 		fi; \
 		echo "✅ terraform.tfvarsを生成しました"; \

--- a/infrastructure/environments/local/main.tf
+++ b/infrastructure/environments/local/main.tf
@@ -47,8 +47,8 @@ resource "aws_secretsmanager_secret_version" "app_secrets" {
     # file()関数を使用することで、JSONの改行やエスケープを正しく処理
     # ファイルが存在しない場合は空文字列を設定（オプショナル対応）
     GOOGLE_SERVICE_ACCOUNT_JSON = var.google_service_account_json_path != "" ? (fileexists(var.google_service_account_json_path) ? file(var.google_service_account_json_path) : "") : ""
-    SLACK_WEBHOOK_URL           = var.slack_webhook_url
     SLACK_BOT_TOKEN             = var.slack_bot_token
+    SLACK_CHANNEL_ID            = var.slack_channel_id
     NOTION_API_KEY              = var.notion_api_key
     NOTION_DATABASE_ID          = var.notion_database_id
     NOTION_TASK_DATABASE_ID     = var.notion_task_database_id

--- a/infrastructure/environments/local/variables.tf
+++ b/infrastructure/environments/local/variables.tf
@@ -53,18 +53,17 @@ variable "gemini_api_key" {
   default     = "dummy-gemini-api-key"
 }
 
-variable "slack_webhook_url" {
-  description = "Slack webhook URL for notifications"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "slack_bot_token" {
   description = "Slack Bot User OAuth Token"
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel ID for notifications"
+  type        = string
+  default     = ""
 }
 
 variable "google_service_account_json_path" {

--- a/infrastructure/environments/production/variables.tf
+++ b/infrastructure/environments/production/variables.tf
@@ -46,11 +46,17 @@ variable "gemini_api_key_secret_name" {
   default     = "minutes-analyzer-gemini-api-key-production"
 }
 
-variable "slack_webhook_url" {
-  description = "Slack webhook URL for notifications"
+variable "slack_bot_token" {
+  description = "Slack Bot User OAuth Token"
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel ID for notifications"
+  type        = string
+  default     = ""
 }
 
 


### PR DESCRIPTION
## 概要
Slack Webhook URLからBot Token/Channel ID方式への移行をインフラ層で対応

## 変更内容
### Terraform変数の更新
- variables.tf: slack_bot_token/slack_channel_id変数を追加
- main.tf: SecretsManagerにBot Token/Channel IDを保存

### Makefile更新
- generate-tfvars: 新しい環境変数を.tfvarsに反映
- Google Service Accountファイルパスの処理を改善

## 影響範囲
- LocalStack環境のSecrets Manager設定
- Terraform apply時の変数要件
- CI/CDパイプラインの環境変数設定