### PR TITLE
feat: Slack Web API対応とスレッド返信機能の実装

### DIFF
--- a/lambda/lib/lambda_handler.rb
+++ b/lambda/lib/lambda_handler.rb
@@ -108,13 +108,16 @@ class LambdaHandler
 
     # Slack通知処理
     begin
-      slack_webhook_url = secrets['SLACK_WEBHOOK_URL']
-      if slack_webhook_url && !slack_webhook_url.empty?
-        @logger.info("Sending Slack notification")
-        slack_client = SlackClient.new(slack_webhook_url, @logger)
+      # Bot TokenとChannel IDを使用
+      slack_bot_token = secrets['SLACK_BOT_TOKEN']
+      slack_channel_id = secrets['SLACK_CHANNEL_ID']
+      
+      if slack_bot_token && !slack_bot_token.empty? && slack_channel_id && !slack_channel_id.empty?
+        @logger.info("Sending Slack notification via Web API")
+        slack_client = SlackClient.new(slack_bot_token, slack_channel_id, @logger)
         results[:slack] = slack_client.send_notification(analysis_result)
       else
-        @logger.warn("Slack webhook URL is not configured")
+        @logger.warn("Slack bot token or channel ID is not configured")
       end
     rescue StandardError => e
       @logger.error("Slack integration failed: #{e.message}")

--- a/lambda/spec/slack_client_spec.rb
+++ b/lambda/spec/slack_client_spec.rb
@@ -4,9 +4,11 @@ require 'webmock/rspec'
 require 'logger'
 
 RSpec.describe SlackClient do
-  let(:webhook_url) { 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX' }
+  let(:bot_token) { 'xoxb-test-token-12345' }
+  let(:channel_id) { 'C1234567890' }
   let(:logger) { instance_double(Logger) }
-  let(:slack_client) { SlackClient.new(webhook_url, logger) }
+  let(:slack_client) { SlackClient.new(bot_token, channel_id, logger) }
+  let(:api_endpoint) { "https://slack.com/api/chat.postMessage" }
 
   before do
     allow(logger).to receive(:info)
@@ -56,56 +58,98 @@ RSpec.describe SlackClient do
     end
 
     context 'when notification is sent successfully' do
+      let(:main_response) do
+        {
+          ok: true,
+          ts: '1234567890.123456',
+          channel: 'C1234567890'
+        }.to_json
+      end
+      
+      let(:thread_response) do
+        {
+          ok: true,
+          ts: '1234567890.123457',
+          channel: 'C1234567890'
+        }.to_json
+      end
+      
       before do
-        stub_request(:post, webhook_url)
-          .to_return(status: 200, body: 'ok')
+        # メインメッセージの送信をスタブ化
+        stub_request(:post, api_endpoint)
+          .with(
+            headers: { 'Authorization' => "Bearer #{bot_token}" }
+          )
+          .to_return(status: 200, body: main_response)
+          .then
+          .to_return(status: 200, body: thread_response)
       end
 
-      it 'returns success' do
+      it 'returns success with timestamp' do
         result = slack_client.send_notification(analysis_result)
         expect(result[:success]).to be true
         expect(result[:response_code]).to eq '200'
+        expect(result[:timestamp]).to eq '1234567890.123456'
       end
 
       it 'logs success message' do
-        expect(logger).to receive(:info).with('Sending notification to Slack')
-        expect(logger).to receive(:info).with('Successfully sent notification to Slack')
+        expect(logger).to receive(:info).with('Sending message to Slack via Web API').at_least(:once)
+        expect(logger).to receive(:info).with('Successfully sent message to Slack').at_least(:once)
         slack_client.send_notification(analysis_result)
       end
     end
 
     context 'when notification fails' do
+      let(:error_response) do
+        {
+          ok: false,
+          error: 'channel_not_found'
+        }.to_json
+      end
+      
       before do
-        stub_request(:post, webhook_url)
-          .to_return(status: 404, body: 'channel_not_found')
+        stub_request(:post, api_endpoint)
+          .with(
+            headers: { 'Authorization' => "Bearer #{bot_token}" }
+          )
+          .to_return(status: 200, body: error_response)
       end
 
       it 'returns failure' do
         result = slack_client.send_notification(analysis_result)
         expect(result[:success]).to be false
-        expect(result[:response_code]).to eq '404'
         expect(result[:error]).to eq 'channel_not_found'
       end
 
       it 'logs error message' do
-        expect(logger).to receive(:error).with(/Failed to send notification to Slack/)
+        expect(logger).to receive(:error).with(/Slack API error: channel_not_found/)
         slack_client.send_notification(analysis_result)
       end
     end
 
-    context 'when webhook URL is not configured' do
-      let(:webhook_url) { nil }
+    context 'when bot token is not configured' do
+      let(:bot_token) { nil }
 
       it 'returns error without making HTTP request' do
         result = slack_client.send_notification(analysis_result)
         expect(result[:success]).to be false
-        expect(result[:message]).to eq 'Webhook URL not configured'
+        expect(result[:message]).to eq 'Bot token not configured'
+      end
+    end
+    
+    context 'when channel ID is not configured' do
+      let(:channel_id) { nil }
+
+      it 'returns error without making HTTP request' do
+        result = slack_client.send_notification(analysis_result)
+        expect(result[:success]).to be false
+        expect(result[:message]).to eq 'Channel ID not configured'
       end
     end
 
     context 'when network error occurs' do
       before do
-        stub_request(:post, webhook_url)
+        stub_request(:post, api_endpoint)
           .to_raise(Net::OpenTimeout.new('execution expired'))
       end
 
@@ -132,13 +176,13 @@ RSpec.describe SlackClient do
       end
 
       before do
-        stub_request(:post, webhook_url)
-          .to_return(status: 200, body: 'ok')
+        stub_request(:post, api_endpoint)
+          .to_return(status: 200, body: { ok: true, ts: '1234567890.123456' }.to_json)
       end
 
       it 'limits participants display to 3 with others count' do
         slack_client.send_notification(analysis_result)
-        expect(WebMock).to have_requested(:post, webhook_url)
+        expect(WebMock).to have_requested(:post, api_endpoint)
           .with { |req| 
             body = JSON.parse(req.body)
             body['blocks'].any? { |block| 
@@ -169,19 +213,81 @@ RSpec.describe SlackClient do
       end
 
       before do
-        stub_request(:post, webhook_url)
-          .to_return(status: 200, body: 'ok')
+        stub_request(:post, api_endpoint)
+          .to_return(status: 200, body: { ok: true, ts: '1234567890.123456' }.to_json)
       end
 
       it 'limits decisions display to 3 with others count' do
         slack_client.send_notification(analysis_result)
-        expect(WebMock).to have_requested(:post, webhook_url)
+        expect(WebMock).to have_requested(:post, api_endpoint)
           .with { |req| 
             body = JSON.parse(req.body)
             body['blocks'].any? { |block| 
               block['text'] && block['text']['text'] && 
               block['text']['text'].include?('…他2件')
             }
+          }
+      end
+    end
+
+    context 'with atmosphere and suggestions for thread reply' do
+      let(:analysis_result) do
+        {
+          'meeting_summary' => {
+            'title' => '新機能リリース進捗確認MTG'
+          },
+          'decisions' => [],
+          'actions' => [],
+          'atmosphere' => {
+            'overall_tone' => 'positive',
+            'evidence' => [
+              '素晴らしい進捗ですね',
+              '順調に進んでいます'
+            ]
+          },
+          'improvement_suggestions' => [
+            {
+              'category' => 'time_management',
+              'suggestion' => 'アクションアイテムには可能な限り具体的な期日を設定しましょう',
+              'expected_impact' => 'タスクの実行が加速し、進捗管理がより明確になります'
+            },
+            {
+              'category' => 'participation',
+              'suggestion' => '各トピックで全員から意見を求める時間を設けると良いでしょう',
+              'expected_impact' => 'チーム全体の当事者意識向上'
+            }
+          ]
+        }
+      end
+
+      before do
+        # メインメッセージとスレッド返信の両方をスタブ化
+        stub_request(:post, api_endpoint)
+          .to_return(status: 200, body: { ok: true, ts: '1234567890.123456' }.to_json)
+          .then
+          .to_return(status: 200, body: { ok: true, ts: '1234567890.123457' }.to_json)
+      end
+
+      it 'sends thread reply with atmosphere and suggestions' do
+        result = slack_client.send_notification(analysis_result)
+        expect(result[:success]).to be true
+        expect(result[:thread_sent]).to be true
+      end
+
+      it 'sends two requests (main and thread)' do
+        slack_client.send_notification(analysis_result)
+        # 2回のリクエスト（メイン通知とスレッド返信）が送信されることを確認
+        expect(WebMock).to have_requested(:post, api_endpoint).times(2)
+      end
+      
+      it 'includes thread_ts in second request' do
+        slack_client.send_notification(analysis_result)
+        
+        # 2番目のリクエストにthread_tsが含まれていることを確認
+        expect(WebMock).to have_requested(:post, api_endpoint)
+          .with { |req| 
+            body = JSON.parse(req.body)
+            body['thread_ts'] == '1234567890.123456'
           }
       end
     end
@@ -198,55 +304,56 @@ RSpec.describe SlackClient do
               'task' => 'Low priority late',
               'assignee' => 'チームA',
               'priority' => 'low',
-              'deadline' => '2025/02/01',
-              'deadline_formatted' => '2025/02/01'
+              'deadline' => '2025/03/01',
+              'deadline_formatted' => '2025/03/01'
             },
             {
-              'task' => 'High priority early',
+              'task' => 'High priority soon',
               'assignee' => 'チームB',
               'priority' => 'high',
               'deadline' => '2025/01/15',
               'deadline_formatted' => '2025/01/15'
             },
             {
-              'task' => 'High priority late',
+              'task' => 'High priority no deadline',
               'assignee' => 'チームC',
               'priority' => 'high',
-              'deadline' => '2025/01/20',
-              'deadline_formatted' => '2025/01/20'
+              'deadline' => nil,
+              'deadline_formatted' => '期日未定'
             },
             {
               'task' => 'Medium priority',
               'assignee' => 'チームD',
               'priority' => 'medium',
-              'deadline' => '2025/01/18',
-              'deadline_formatted' => '2025/01/18'
+              'deadline' => '2025/02/01',
+              'deadline_formatted' => '2025/02/01'
             }
           ],
           'actions_summary' => {
-            'total_count' => 4
+            'total_count' => 4,
+            'with_deadline' => 3,
+            'without_deadline' => 1,
+            'high_priority_count' => 2
           }
         }
       end
 
       before do
-        stub_request(:post, webhook_url)
-          .to_return(status: 200, body: 'ok')
+        stub_request(:post, api_endpoint)
+          .to_return(status: 200, body: { ok: true, ts: '1234567890.123456' }.to_json)
       end
 
       it 'sorts actions by priority then deadline' do
         slack_client.send_notification(analysis_result)
-        expect(WebMock).to have_requested(:post, webhook_url)
+        expect(WebMock).to have_requested(:post, api_endpoint)
           .with { |req| 
             body = JSON.parse(req.body)
-            actions_text = body['blocks'].find { |b| 
-              b['text'] && b['text']['text'] && b['text']['text'].include?('アクション一覧')
-            }['text']['text']
+            actions_text = body['blocks'].find { |b| b['text'] && b['text']['text'] && b['text']['text'].include?('アクション一覧') }['text']['text']
             
-            # Verify order: High priority early, High priority late, Medium priority
-            actions_text.include?('High priority early') &&
-            actions_text.index('High priority early') < actions_text.index('High priority late') &&
-            actions_text.index('High priority late') < actions_text.index('Medium priority')
+            # 期待される順序: High priority soon, High priority no deadline, Medium priority
+            actions_text.include?('High priority soon') &&
+            actions_text.index('High priority soon') < actions_text.index('High priority no deadline') &&
+            actions_text.index('High priority no deadline') < actions_text.index('Medium priority')
           }
       end
     end


### PR DESCRIPTION
## 概要
Slack Webhook URLからWeb APIベースの実装に移行し、スレッド返信による詳細情報の配信を実現

## 変更内容
### SlackClientの刷新
- Webhook URLからBot Token/Channel ID方式に移行
- chat.postMessage APIを使用した送信処理
- メインメッセージとスレッド返信の2段階配信

### 新機能
- 会議の雰囲気分析をスレッド返信で配信
- 改善提案をスレッド返信で配信
- アクション項目の優先度/期日順ソート

### テストの更新
- Bot Token/Channel ID対応のテストケース
- スレッド返信のテスト追加
- Web APIレスポンスのモック更新

## 影響範囲
- Slack通知の配信フォーマット改善
- 既存Webhook URLベースの設定は非互換