### PR TITLE
refactor: 決定事項から決定者とタイムスタンプフィールドを削除

### DIFF
--- a/prompts/output_schema.json
+++ b/prompts/output_schema.json
@@ -23,11 +23,9 @@
           "category": {
             "type": "string",
             "enum": ["pricing", "schedule", "policy", "other"]
-          },
-          "timestamp": {"type": "string", "pattern": "^\\d{2}:\\d{2}:\\d{2}$"},
-          "decided_by": {"type": "string"}
+          }
         },
-        "required": ["content", "category", "timestamp", "decided_by"]
+        "required": ["content", "category"]
       }
     },
     "actions": {


### PR DESCRIPTION
## 📋 概要
決定事項の出力スキーマから`decided_by`（決定者）と`timestamp`（タイムスタンプ）フィールドを削除し、よりシンプルな出力形式にします。

## 🎯 目的
- 決定事項の本質的な内容（決定内容とカテゴリ）に集中
- 不要なメタデータを削除してデータ構造を簡潔化
- Notion出力時の冗長な情報表示を削減

## 🔧 変更内容
### prompts/output_schema.json
- `decisions`配列内の`decided_by`フィールドを削除
- `decisions`配列内の`timestamp`フィールドを削除
- `required`配列から両フィールドを削除

## ✅ 確認観点
- [ ] JSONスキーマが有効な形式を保持している
- [ ] `decisions`オブジェクトに`decided_by`と`timestamp`が存在しない
- [ ] `required`フィールドに必要最小限の項目のみが含まれている

## 📊 影響範囲
- Gemini APIからの出力形式が変更される
- 後続タスクでプロンプト、Notion連携、テストの更新が必要

## 🔗 関連タスク
- T-01: 出力スキーマから決定者とタイムスタンプフィールドを削除（本PR）
- T-02: Gemini APIプロンプトから決定者とタイムスタンプの抽出指示を削除
- T-03: Notion連携処理から決定者とタイムスタンプの表示を削除
- T-04: テストケースとモックデータの更新
- T-05: 統合テストの実施とドキュメント更新