### PR TITLE
refactor: プロンプトから決定者とタイムスタンプの抽出指示を削除

### DIFF
--- a/prompts/meeting_analysis_prompt.txt
+++ b/prompts/meeting_analysis_prompt.txt
@@ -24,7 +24,6 @@
 議事録全体（まとめ、詳細、文字起こし）から、明確に決定された事項を抽出してください。
 - 「決定」「確認」「合意」「設定」等の表現に注目
 - 価格設定、スケジュール、方針、合意事項など
-- 各決定事項にタイムスタンプと決定者を付与
 
 ## 2. 今後のアクションの分析
 議事録全体から、実行すべきタスクを抽出し、以下の情報を付与してください。
@@ -78,9 +77,7 @@
   "decisions": [
     {
       "content": "決定内容",
-      "category": "pricing/schedule/policy/other",
-      "timestamp": "HH:MM:SS",
-      "decided_by": "決定者名"
+      "category": "pricing/schedule/policy/other"
     }
   ],
   "actions": [


### PR DESCRIPTION
## 📋 概要
Gemini APIプロンプトから決定者とタイムスタンプの抽出指示を削除し、出力スキーマとの整合性を保ちます。

## 🎯 目的
- T-01で変更した出力スキーマとプロンプトの整合性確保
- 不要な情報抽出指示の削除
- よりシンプルで効率的な分析処理の実現

## 🔧 変更内容
### prompts/meeting_analysis_prompt.txt
- 決定事項抽出の分析指示から「各決定事項にタイムスタンプと決定者を付与」の記述を削除
- JSON出力例から`decided_by`と`timestamp`フィールドを削除

## ✅ 確認観点
- [ ] プロンプトにdecided_byとtimestampへの言及がない
- [ ] JSON出力例が出力スキーマと一致している
- [ ] 分析指示の一貫性が保たれている

## 📊 影響範囲
- Gemini APIの分析結果が新しい形式で出力される
- 後続タスクでNotion連携とテストの更新が必要

## 🔗 関連タスク
- T-01: 出力スキーマから決定者とタイムスタンプフィールドを削除（完了）
- T-02: Gemini APIプロンプトから決定者とタイムスタンプの抽出指示を削除（本PR）
- T-03: Notion連携処理から決定者とタイムスタンプの表示を削除
- T-04: テストケースとモックデータの更新
- T-05: 統合テストの実施とドキュメント更新

## 📝 前提PR
- #100: refactor/decisions-remove-metadata