### PR TITLE
refactor: Notion連携から決定者とタイムスタンプの表示を削除

### DIFF
--- a/lambda/lib/notion_integration_service.rb
+++ b/lambda/lib/notion_integration_service.rb
@@ -187,8 +187,6 @@ class NotionIntegrationService
     decisions.each do |decision|
       next unless decision.is_a?(Hash)
       text = "#{decision['content'] || '内容不明'}"
-      text += " (#{decision['decided_by']}により決定)" if decision['decided_by']
-      text += " [#{decision['timestamp']}]" if decision['timestamp']
 
       section << {
         type: "bulleted_list_item",


### PR DESCRIPTION
## 📋 概要
Notion連携処理から決定事項の決定者とタイムスタンプ表示を削除し、決定内容のみのシンプルな表示に変更します。

## 🎯 目的
- 出力スキーマとプロンプトの変更に合わせてNotion表示を更新
- 冗長な情報を削除してよりクリーンな議事録表示を実現
- 決定内容そのものに焦点を当てた表示

## 🔧 変更内容
### lambda/lib/notion_integration_service.rb
- 190行目: 決定者表示処理（`decided_by`フィールドによる表示）を削除
- 191行目: タイムスタンプ表示処理（`timestamp`フィールドによる表示）を削除
- 決定内容（`content`）のみを表示するシンプルな実装に変更

## ✅ 確認観点
- [ ] 決定事項の内容が正しく表示される
- [ ] 決定者とタイムスタンプの表示コードが完全に削除されている
- [ ] Notion APIへの送信データが正しい形式を保持している

## 📊 影響範囲
- Notionに作成される議事録ページの決定事項セクション表示
- 後続タスクでテストの更新が必要

## 🔗 関連タスク
- T-01: 出力スキーマから決定者とタイムスタンプフィールドを削除（完了）
- T-02: Gemini APIプロンプトから決定者とタイムスタンプの抽出指示を削除（完了）
- T-03: Notion連携処理から決定者とタイムスタンプの表示を削除（本PR）
- T-04: テストケースとモックデータの更新
- T-05: 統合テストの実施とドキュメント更新

## 📝 前提PR
- #100: refactor/decisions-remove-metadata
- #101: refactor/prompts-remove-metadata