### PR TITLE
fix: #128 Fix failing tests in google-driver-lambda-test.yml

### DIFF
--- a/drive-selector/lambda/handler.rb
+++ b/drive-selector/lambda/handler.rb
@@ -97,7 +97,7 @@ end
 def health_check
   {
     statusCode: 200,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type' => 'application/json' },
     body: JSON.generate({
       status: 'healthy',
       timestamp: Time.now.iso8601
@@ -190,7 +190,7 @@ end
 def error_response(message)
   {
     statusCode: 500,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type' => 'application/json' },
     body: JSON.generate({
       error: 'Internal Server Error',
       message: message

--- a/drive-selector/lambda/lib/slack_command_handler.rb
+++ b/drive-selector/lambda/lib/slack_command_handler.rb
@@ -24,11 +24,11 @@ class SlackCommandHandler
       when '/meet-transcript'
         handle_meet_transcript(user_id, team_id, trigger_id)
       else
-        unknown_command_response(command)
+        create_api_response(unknown_command_response(command))
       end
     rescue => e
       puts "Error processing command: #{e.message}"
-      create_error_response('認証サービスにアクセスできません。しばらくしてからもう一度お試しください。', 500)
+      create_api_response(create_error_response('認証サービスにアクセスできません。しばらくしてからもう一度お試しください。', 500), 500)
     end
   end
 
@@ -46,72 +46,65 @@ class SlackCommandHandler
     # ユーザーが認証済みか確認
     if @oauth_client.authenticated?(user_id)
       # 認証済みの場合、成功レスポンスを返す（T-04でモーダル実装）
-      create_success_response
+      create_api_response(create_success_response)
     else
       # 未認証の場合、認証URLを返す
       auth_url = @oauth_client.generate_auth_url(user_id)
-      create_auth_required_response(auth_url)
+      create_api_response(create_auth_required_response(auth_url))
     end
   end
 
   # 認証が必要な場合のレスポンス
   def create_auth_required_response(auth_url)
     {
-      statusCode: 200,
-      headers: { 'Content-Type' => 'application/json' },
-      body: JSON.generate({
-        response_type: 'ephemeral',
-        text: 'Google Driveにアクセスするための認証が必要です。安全な接続で認証を行います。',
-        attachments: [
-          {
-            color: 'good',
-            actions: [
-              {
-                type: 'button',
-                text: 'Google Driveを認証',
-                url: auth_url,
-                style: 'primary'
-              }
-            ]
-          }
-        ]
-      })
+      response_type: 'ephemeral',
+      text: 'Google Driveにアクセスするための認証が必要です。安全な接続で認証を行います。',
+      attachments: [
+        {
+          color: 'good',
+          actions: [
+            {
+              type: 'button',
+              text: 'Google Driveを認証',
+              url: auth_url,
+              style: 'primary'
+            }
+          ]
+        }
+      ]
     }
   end
 
   # 成功レスポンス
   def create_success_response
     {
-      statusCode: 200,
-      headers: { 'Content-Type' => 'application/json' },
-      body: JSON.generate({
-        response_type: 'ephemeral',
-        text: 'Google Drive検索を開始します。検索用のモーダルを表示しますので、しばらくお待ちください。'
-      })
+      response_type: 'ephemeral',
+      text: 'Google Drive検索を開始します。検索用のモーダルを表示しますので、しばらくお待ちください。'
     }
   end
 
   # エラーレスポンス
   def create_error_response(error_message, status_code = 400)
     {
-      statusCode: status_code,
-      headers: { 'Content-Type' => 'application/json' },
-      body: JSON.generate({
-        response_type: 'ephemeral',
-        text: error_message
-      })
+      response_type: 'ephemeral',
+      text: error_message
     }
   end
 
   # 不明なコマンドの場合のレスポンス
   def unknown_command_response(command)
     {
-      statusCode: 200,
+      response_type: 'ephemeral',
+      text: "未対応のコマンド: #{command}"
+    }
+  end
+
+  # API Gateway レスポンス形式にラップ
+  def create_api_response(content, status_code = 200)
+    {
+      statusCode: status_code,
       headers: { 'Content-Type' => 'application/json' },
-      body: JSON.generate({
-        response_type: 'ephemeral',
-        text: "未対応のコマンド: #{command}"
-      })
+      body: JSON.generate(content)
     }
   end
 end


### PR DESCRIPTION
- Fix GoogleOAuthClient: Use instance variable @token_cache instead of @@tokens_cache
- Fix handler.rb: Correct hash syntax from '':'' to ''=>'' for Content-Type headers
- Fix SlackCommandHandler: Separate private methods (return JSON) from public methods (API Gateway format)
- Fix SlackInteractionHandler: Add API Gateway response wrapping
- Fix SlackRequestValidator: Fix parameter order and add missing valid_signature? method
- Add missing JSON require to SlackRequestValidator