### PR TITLE
feat: drive-selectorのOAuthトークン管理をDynamoDB化

### DIFF
--- a/drive-selector/README.md
+++ b/drive-selector/README.md
@@ -9,52 +9,6 @@ Google Drive ファイル選択機能を提供する Slack Bot です。Slack �
 - 選択したファイルを議事録分析 Lambda へ送信
 - 分析開始時の Slack 通知（メンション付き）
 
-## 環境変数
-
-### 必須
-
-- `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token
-- `SLACK_SIGNING_SECRET`: Slack アプリの署名シークレット
-- `GOOGLE_CLIENT_ID`: Google OAuth 2.0 クライアント ID
-- `GOOGLE_CLIENT_SECRET`: Google OAuth 2.0 クライアントシークレット
-- `PROCESS_LAMBDA_ARN`: 議事録分析 Lambda の ARN
-
-### オプション
-
-- `SLACK_CHANNEL_ID`: 通知を送信する Slack チャンネル ID（例: C1234567890）
-  - 設定されている場合、分析開始時にチャンネルに通知を送信
-  - 未設定の場合、実行ユーザーにのみエフェメラルメッセージを送信
-
-## デプロイ
-
-### 開発環境
-
-```bash
-cd infrastructure
-terraform init
-terraform plan -var-file=terraform.tfvars
-terraform apply -var-file=terraform.tfvars
-```
-
-### 本番環境
-
-```bash
-cd infrastructure
-terraform init
-terraform plan -var-file=terraform.production.tfvars
-terraform apply -var-file=terraform.production.tfvars
-```
-
-## Lambda 関数名
-
-- 開発環境: `drive-selector-controller-development`
-- 本番環境: `drive-selector-production`
-
-## CloudWatch ログ
-
-- 開発環境: `/aws/lambda/drive-selector-controller-development`
-- 本番環境: `/aws/lambda/drive-selector-production`
-
 ## アーキテクチャ
 
 ```
@@ -68,17 +22,82 @@ Lambda (drive-selector)
     └→ Lambda (minutes-analyzer-production) [非同期呼び出し]
 ```
 
-## 通知フォーマット
+## DynamoDB トークン管理
 
-分析開始時に以下の形式で Slack に通知されます：
+OAuth トークンは DynamoDB テーブルで永続化されます：
 
+### テーブル構造
+- **テーブル名**: `{project_name}-oauth-tokens-{environment}`
+- **パーティションキー**: `user_id` (SlackユーザーID)
+- **属性**:
+  - `access_token`: Google OAuth アクセストークン
+  - `refresh_token`: Google OAuth リフレッシュトークン
+  - `expires_at`: トークン有効期限 (UNIX timestamp)
+  - `created_at`: 作成日時 (UNIX timestamp)
+  - `updated_at`: 更新日時 (UNIX timestamp)
+
+### 特徴
+- KMS暗号化による at-rest セキュリティ
+- TTL設定による期限切れトークンの自動削除
+- 自動リフレッシュ機能（有効期限5分前に実行）
+
+## 環境変数
+
+### 必須
+
+- `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token
+- `SLACK_SIGNING_SECRET`: Slack アプリの署名シークレット
+- `GOOGLE_CLIENT_ID`: Google OAuth 2.0 クライアント ID
+- `GOOGLE_CLIENT_SECRET`: Google OAuth 2.0 クライアントシークレット
+- `PROCESS_LAMBDA_ARN`: 議事録分析 Lambda の ARN
+- `OAUTH_TOKENS_TABLE_NAME`: DynamoDB トークンテーブル名
+- `SLACK_CHANNEL_ID`: 通知を送信する Slack チャンネル ID（例: C1234567890）
+
+## デプロイ
+
+### 本番環境
+
+```bash
+cd infrastructure/environments/production
+terraform init
+terraform plan -var-file=terraform.tfvars
+terraform apply -var-file=terraform.tfvars
 ```
-🔄 議事録分析を開始しました
-実行者: @username
-対象ファイル: ファイル名
+
+## Lambda関数の詳細
+
+### 主要コンポーネント
+
+- `handler.rb` - メインハンドラー
+- `lib/google_oauth_client.rb` - OAuth認証管理（DynamoDB連携）
+- `lib/dynamodb_token_store.rb` - DynamoDBトークン管理
+- `lib/google_drive_client.rb` - Drive API連携
+- `lib/slack_command_handler.rb` - Slashコマンド処理
+- `lib/slack_interaction_handler.rb` - インタラクション処理
+
+### OAuth トークンフロー
+
+1. ユーザーが `/meeting-analyzer` コマンドを実行
+2. 認証が必要な場合、Google OAuth URLにリダイレクト
+3. 認証完了後、トークンをDynamoDBに保存
+4. 以降のリクエストでは DynamoDB からトークンを取得
+5. トークン有効期限が近い場合、自動的にリフレッシュ
+
+## テスト
+
+```bash
+cd lambda
+bundle install
+bundle exec rspec
 ```
 
 ## トラブルシューティング
+
+### OAuth トークンエラー
+
+1. DynamoDB テーブルへのアクセス権限を確認
+2. `OAUTH_TOKENS_TABLE_NAME` が正しく設定されているか確認
+3. トークンの有効期限が切れていないか確認（自動リフレッシュされるはず）
 
 ### Lambda 呼び出しが動作しない場合
 
@@ -86,179 +105,12 @@ Lambda (drive-selector)
 2. `PROCESS_LAMBDA_ARN` が正しく設定されているか確認
 3. IAM ロールに `lambda:InvokeFunction` 権限があるか確認
 
-### Slack 通知が送信されない場合
+### DynamoDB アクセスエラー
 
-1. `SLACK_CHANNEL_ID` が正しく設定されているか確認
-2. Slack Bot がチャンネルに招待されているか確認
-3. `chat:write` スコープが付与されているか確認
-=======
-# Drive Selector - Slack Bot Drive連携機能
-
-Slack上でGoogle Driveファイル（Meet文字起こし）を検索・選択し、既存の議事録分析Lambdaへ起動リクエストを送るマイクロサービスです。
-
-## 機能概要
-
-- `/meet-transcript` コマンドでGoogle Driveファイルを検索・選択
-- OAuth 2.0認証によるセキュアなGoogle Drive連携
-- 選択したファイルを既存の議事録分析Lambdaに送信
-- 非同期処理による快適なユーザー体験
-
-## アーキテクチャ
-
-```
-Slack ←→ API Gateway ←→ Lambda (Controller) ←→ Google Drive API
-                              ↓
-                      既存議事録分析Lambda
-```
-
-## セットアップ
-
-### 前提条件
-
-- AWS アカウント
-- Slack ワークスペース管理者権限
-- Google Cloud Console アクセス権限
-- Terraform v1.0以上
-- Ruby 3.2
-
-### 1. Slack App設定
-
-1. [Slack API](https://api.slack.com/apps)で新規アプリを作成
-2. OAuth & Permissions で以下のスコープを追加：
-   - `commands` - Slashコマンドの使用
-   - `users:read.email` - ユーザーメールアドレスの取得
-   - `chat:write` - メッセージの送信
-3. Slash Commands で `/meet-transcript` コマンドを追加
-4. Interactivity & Shortcuts を有効化
-5. Bot User OAuth Token を取得
-
-### 2. Google OAuth設定
-
-1. [Google Cloud Console](https://console.cloud.google.com/)でプロジェクトを作成
-2. OAuth 2.0 クライアントIDを作成
-3. 承認済みリダイレクトURIを設定
-4. クライアントID・シークレットを取得
-
-### 3. 環境変数設定
-
-```bash
-# 開発環境
-cp .env.local.sample .env.local
-# 実際の値を設定
-vi .env.local
-
-# 本番環境
-cp .env.production.sample .env.production
-# 実際の値を設定
-vi .env.production
-```
-
-### 4. インフラストラクチャのデプロイ
-
-```bash
-cd infrastructure
-
-# 初期化
-terraform init
-
-# 設定ファイルをコピー
-cp terraform.tfvars.sample terraform.tfvars
-# 実際の値を設定
-vi terraform.tfvars
-
-# デプロイ
-terraform plan
-terraform apply
-```
-
-## Lambda関数の詳細
-
-### ハンドラー構成
-
-- `handler.rb` - メインハンドラー
-- `lib/slack_verifier.rb` - Slack署名検証
-- `lib/slack_command_handler.rb` - Slashコマンド処理
-- `lib/slack_interaction_handler.rb` - インタラクション処理
-- `lib/slack_modal_builder.rb` - モーダルUI構築
-- `lib/google_oauth_client.rb` - OAuth認証管理
-- `lib/google_drive_client.rb` - Drive API連携
-- `lib/lambda_invoker.rb` - 既存Lambda呼び出し
-
-### Lambda Invoke連携
-
-`LambdaInvoker`クラスが既存の議事録分析Lambdaを非同期で呼び出します：
-
-```ruby
-# ペイロード形式
-{
-  "body": "{\"file_id\": \"...\", \"file_name\": \"...\"}",
-  "headers": {"Content-Type": "application/json"}
-}
-```
-
-### 環境変数
-
-- `PROCESS_LAMBDA_ARN` - 既存議事録分析LambdaのARN
-- `SLACK_SIGNING_SECRET` - Slack署名検証用シークレット
-- `SLACK_BOT_TOKEN` - Slack Bot OAuth Token
-- `GOOGLE_CLIENT_ID` - Google OAuth クライアントID
-- `GOOGLE_CLIENT_SECRET` - Google OAuth クライアントシークレット
-- `SECRETS_MANAGER_SECRET_ID` - AWS Secrets ManagerのシークレットID
-
-## テスト
-
-```bash
-cd lambda
-
-# 依存関係インストール
-bundle install
-
-# テスト実行
-bundle exec rspec
-
-# カバレッジレポート
-open coverage/index.html
-```
-
-## デバッグ
-
-CloudWatch Logsでログを確認：
-
-```bash
-# 開発環境
-aws logs tail /aws/lambda/drive-selector-controller-development --follow
-
-# 本番環境
-aws logs tail /aws/lambda/drive-selector-controller-production --follow
-```
-
-## トラブルシューティング
-
-### Slack署名検証エラー
-
-- `SLACK_SIGNING_SECRET`が正しく設定されているか確認
-- リクエストのタイムスタンプが5分以内か確認
-
-### Google認証エラー
-
-- OAuth クライアントIDとシークレットが正しいか確認
-- リダイレクトURIが承認済みリストに含まれているか確認
-- DynamoDBのトークンテーブルにアクセス権限があるか確認
-
-### Lambda Invoke失敗
-
-- `PROCESS_LAMBDA_ARN`が正しく設定されているか確認
-- IAMロールにLambda InvokeFunction権限があるか確認
-- ターゲットLambdaが存在し、アクティブか確認
-
-## セキュリティ考慮事項
-
-- Slack署名検証により、なりすましリクエストを防止
-- OAuth 2.0によるセキュアなGoogle Drive連携
-- DynamoDBのデフォルト暗号化によるトークン保護
-- Secrets Managerによる機密情報の安全な管理
-- 最小権限の原則に基づくIAMロール設定
-
-## ライセンス
-
-[プロジェクトのライセンスに準拠]
+1. Lambda実行ロールにDynamoDB権限があるか確認:
+   - `dynamodb:GetItem`
+   - `dynamodb:PutItem`
+   - `dynamodb:UpdateItem`
+   - `dynamodb:DeleteItem`
+2. `OAUTH_TOKENS_TABLE_NAME` 環境変数が設定されているか確認
+3. DynamoDBテーブルが存在し、適切なキー設定になっているか確認

--- a/drive-selector/lambda/Gemfile
+++ b/drive-selector/lambda/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'aws-sdk-lambda', '~> 1.0'
 gem 'aws-sdk-secretsmanager', '~> 1.0'
 gem 'aws-sdk-sts', '~> 1.0'
-# aws-sdk-dynamodb removed - using session-based authentication instead
+gem 'aws-sdk-dynamodb', '~> 1.0'
 
 # Google APIs
 gem 'google-apis-drive_v3', '~> 0.44'

--- a/drive-selector/lambda/Gemfile.lock
+++ b/drive-selector/lambda/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+    aws-sdk-dynamodb (1.149.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-lambda (1.158.0)
       aws-sdk-core (~> 3, >= 3.228.0)
       aws-sigv4 (~> 1.5)
@@ -165,6 +168,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-dynamodb (~> 1.0)
   aws-sdk-lambda (~> 1.0)
   aws-sdk-secretsmanager (~> 1.0)
   aws-sdk-sts (~> 1.0)

--- a/drive-selector/lambda/lib/google_oauth_client.rb
+++ b/drive-selector/lambda/lib/google_oauth_client.rb
@@ -6,20 +6,17 @@ require 'json'
 require 'base64'
 require 'securerandom'
 require 'aws-sdk-secretsmanager'
+require_relative 'dynamodb_token_store'
 
 class GoogleOAuthClient
   GOOGLE_OAUTH_BASE_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
   GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
   GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly'
 
-  # Lambdaメモリ内でのトークンキャッシュ（Lambda実行期間中のみ有効）
-  @@tokens_cache = {}
-  MAX_CACHE_SIZE = 100  # キャッシュサイズ制限
-  EXPIRY_BUFFER = 300   # トークン期限のバッファ（5分）
-
   def initialize
     @client_id = fetch_secret('GOOGLE_CLIENT_ID')
     @client_secret = fetch_secret('GOOGLE_CLIENT_SECRET')
+    @token_store = DynamoDbTokenStore.new
   end
 
   # 認証URLを生成
@@ -82,43 +79,31 @@ class GoogleOAuthClient
     end
   end
 
-  # ユーザーのトークンをメモリキャッシュに保存
+  # ユーザーのトークンをDynamoDBに保存
   def save_tokens(slack_user_id, tokens)
-    # キャッシュサイズ制限（LRU風の簡単な削除）
-    if @@tokens_cache.size >= MAX_CACHE_SIZE
-      # 最も古いエントリを削除
-      oldest_key = @@tokens_cache.keys.first
-      @@tokens_cache.delete(oldest_key)
-    end
-
-    @@tokens_cache[slack_user_id] = {
-      access_token: tokens['access_token'],
-      refresh_token: tokens['refresh_token'],
-      expires_at: Time.now.to_i + (tokens['expires_in'] || 3600),
-      created_at: Time.now.to_i,
-      updated_at: Time.now.to_i
-    }
+    @token_store.save_tokens(slack_user_id, tokens)
   end
 
-  # ユーザーのトークンをメモリキャッシュから取得
+  # ユーザーのトークンをDynamoDBから取得
   def get_tokens(slack_user_id, refresh_attempted: false)
-    cached_token = @@tokens_cache[slack_user_id]
-    return nil unless cached_token
+    stored_token = @token_store.get_tokens(slack_user_id)
+    return nil unless stored_token
 
-    # トークンの有効期限を確認（バッファ付き）
-    if cached_token[:expires_at] && cached_token[:expires_at] < (Time.now.to_i + EXPIRY_BUFFER)
+    # トークンの有効期限を確認（DynamoDbTokenStoreで既にチェック済み）
+    # ただし、期限切れの場合はリフレッシュを試行
+    if stored_token[:expires_at] && stored_token[:expires_at] < (Time.now.to_i + 300)
       return nil if refresh_attempted  # 無限再帰を防止
 
       # アクセストークンの有効期限が切れている場合、リフレッシュ
-      if cached_token[:refresh_token]
+      if stored_token[:refresh_token]
         begin
-          new_tokens = refresh_access_token(cached_token[:refresh_token])
-          save_tokens(slack_user_id, new_tokens)
+          new_tokens = refresh_access_token(stored_token[:refresh_token])
+          @token_store.update_tokens(slack_user_id, new_tokens)
           return get_tokens(slack_user_id, refresh_attempted: true)
         rescue => e
           puts "Token refresh failed: #{e.message}"
-          # リフレッシュに失敗した場合はキャッシュからトークンを削除
-          @@tokens_cache.delete(slack_user_id)
+          # リフレッシュに失敗した場合はDynamoDBからトークンを削除
+          @token_store.delete_tokens(slack_user_id)
           return nil
         end
       else
@@ -126,22 +111,17 @@ class GoogleOAuthClient
       end
     end
 
-    {
-      access_token: cached_token[:access_token],
-      refresh_token: cached_token[:refresh_token],
-      expires_at: cached_token[:expires_at]
-    }
+    stored_token
   end
 
   # ユーザーが認証済みかチェック
   def authenticated?(slack_user_id)
-    tokens = get_tokens(slack_user_id)
-    !tokens.nil? && !tokens[:access_token].nil?
+    @token_store.authenticated?(slack_user_id)
   end
 
-  # トークンをメモリキャッシュから削除（ログアウト）
+  # トークンをDynamoDBから削除（ログアウト）
   def delete_tokens(slack_user_id)
-    @@tokens_cache.delete(slack_user_id)
+    @token_store.delete_tokens(slack_user_id)
   end
 
   private

--- a/drive-selector/lambda/spec/lib/dynamodb_token_store_spec.rb
+++ b/drive-selector/lambda/spec/lib/dynamodb_token_store_spec.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../lib/dynamodb_token_store'
+
+RSpec.describe DynamoDbTokenStore do
+  let(:table_name) { 'test-oauth-tokens' }
+  let(:mock_dynamodb) { double('Aws::DynamoDB::Client') }
+  let(:token_store) { DynamoDbTokenStore.new }
+  let(:slack_user_id) { 'U12345678' }
+  let(:tokens) do
+    {
+      'access_token' => 'ya29.test_access_token',
+      'refresh_token' => 'refresh_token_123',
+      'expires_in' => 3600
+    }
+  end
+
+  before do
+    ENV['OAUTH_TOKENS_TABLE_NAME'] = table_name
+    allow(Aws::DynamoDB::Client).to receive(:new).and_return(mock_dynamodb)
+  end
+
+  after do
+    ENV.delete('OAUTH_TOKENS_TABLE_NAME')
+  end
+
+  describe '#initialize' do
+    context 'when OAUTH_TOKENS_TABLE_NAME is not set' do
+      before { ENV.delete('OAUTH_TOKENS_TABLE_NAME') }
+
+      it 'raises an error' do
+        expect { DynamoDbTokenStore.new }.to raise_error('OAUTH_TOKENS_TABLE_NAME environment variable not set')
+      end
+    end
+
+    context 'when OAUTH_TOKENS_TABLE_NAME is set' do
+      it 'initializes successfully' do
+        expect { DynamoDbTokenStore.new }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#save_tokens' do
+    it 'saves tokens to DynamoDB' do
+      expected_item = {
+        user_id: slack_user_id,
+        access_token: tokens['access_token'],
+        refresh_token: tokens['refresh_token'],
+        expires_at: kind_of(Integer),
+        created_at: kind_of(Integer),
+        updated_at: kind_of(Integer)
+      }
+
+      expect(mock_dynamodb).to receive(:put_item).with(
+        table_name: table_name,
+        item: expected_item
+      )
+
+      token_store.save_tokens(slack_user_id, tokens)
+    end
+
+    context 'when refresh_token is nil' do
+      let(:tokens_without_refresh) do
+        {
+          'access_token' => 'ya29.test_access_token',
+          'refresh_token' => nil,
+          'expires_in' => 3600
+        }
+      end
+
+      it 'does not include refresh_token in the item' do
+        expected_item = {
+          user_id: slack_user_id,
+          access_token: tokens_without_refresh['access_token'],
+          expires_at: kind_of(Integer),
+          created_at: kind_of(Integer),
+          updated_at: kind_of(Integer)
+        }
+
+        expect(mock_dynamodb).to receive(:put_item).with(
+          table_name: table_name,
+          item: expected_item
+        )
+
+        token_store.save_tokens(slack_user_id, tokens_without_refresh)
+      end
+    end
+  end
+
+  describe '#get_tokens' do
+    let(:current_time) { Time.now.to_i }
+    let(:valid_expires_at) { current_time + 1800 } # 30 minutes from now
+
+    context 'when tokens exist and are valid' do
+      let(:dynamodb_response) do
+        double('response', item: {
+          'user_id' => slack_user_id,
+          'access_token' => tokens['access_token'],
+          'refresh_token' => tokens['refresh_token'],
+          'expires_at' => valid_expires_at
+        })
+      end
+
+      it 'returns the tokens' do
+        expect(mock_dynamodb).to receive(:get_item).with(
+          table_name: table_name,
+          key: { user_id: slack_user_id }
+        ).and_return(dynamodb_response)
+
+        result = token_store.get_tokens(slack_user_id)
+
+        expect(result).to eq({
+          access_token: tokens['access_token'],
+          refresh_token: tokens['refresh_token'],
+          expires_at: valid_expires_at
+        })
+      end
+    end
+
+    context 'when tokens do not exist' do
+      let(:dynamodb_response) { double('response', item: nil) }
+
+      it 'returns nil' do
+        expect(mock_dynamodb).to receive(:get_item).with(
+          table_name: table_name,
+          key: { user_id: slack_user_id }
+        ).and_return(dynamodb_response)
+
+        result = token_store.get_tokens(slack_user_id)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when tokens are expired' do
+      let(:expired_expires_at) { current_time - 100 } # Expired 100 seconds ago
+      let(:dynamodb_response) do
+        double('response', item: {
+          'user_id' => slack_user_id,
+          'access_token' => tokens['access_token'],
+          'refresh_token' => tokens['refresh_token'],
+          'expires_at' => expired_expires_at
+        })
+      end
+
+      it 'returns nil' do
+        expect(mock_dynamodb).to receive(:get_item).with(
+          table_name: table_name,
+          key: { user_id: slack_user_id }
+        ).and_return(dynamodb_response)
+
+        result = token_store.get_tokens(slack_user_id)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when DynamoDB raises an error' do
+      it 'returns nil and logs the error' do
+        expect(mock_dynamodb).to receive(:get_item).and_raise(
+          Aws::DynamoDB::Errors::ServiceError.new('context', 'Test error')
+        )
+        expect { token_store.get_tokens(slack_user_id) }.to output(/DynamoDB get_item error/).to_stdout
+
+        result = token_store.get_tokens(slack_user_id)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#update_tokens' do
+    let(:new_tokens) do
+      {
+        'access_token' => 'new_access_token',
+        'refresh_token' => 'new_refresh_token',
+        'expires_in' => 3600
+      }
+    end
+
+    it 'updates tokens in DynamoDB' do
+      expect(mock_dynamodb).to receive(:update_item).with(
+        table_name: table_name,
+        key: { user_id: slack_user_id },
+        update_expression: 'SET access_token = :access_token, expires_at = :expires_at, updated_at = :updated_at, refresh_token = :refresh_token',
+        expression_attribute_values: {
+          ':access_token' => new_tokens['access_token'],
+          ':expires_at' => kind_of(Integer),
+          ':updated_at' => kind_of(Integer),
+          ':refresh_token' => new_tokens['refresh_token']
+        }
+      )
+
+      token_store.update_tokens(slack_user_id, new_tokens)
+    end
+
+    context 'when refresh_token is not provided' do
+      let(:new_tokens_without_refresh) do
+        {
+          'access_token' => 'new_access_token',
+          'expires_in' => 3600
+        }
+      end
+
+      it 'does not include refresh_token in update' do
+        expect(mock_dynamodb).to receive(:update_item).with(
+          table_name: table_name,
+          key: { user_id: slack_user_id },
+          update_expression: 'SET access_token = :access_token, expires_at = :expires_at, updated_at = :updated_at',
+          expression_attribute_values: {
+            ':access_token' => new_tokens_without_refresh['access_token'],
+            ':expires_at' => kind_of(Integer),
+            ':updated_at' => kind_of(Integer)
+          }
+        )
+
+        token_store.update_tokens(slack_user_id, new_tokens_without_refresh)
+      end
+    end
+  end
+
+  describe '#delete_tokens' do
+    it 'deletes tokens from DynamoDB' do
+      expect(mock_dynamodb).to receive(:delete_item).with(
+        table_name: table_name,
+        key: { user_id: slack_user_id }
+      )
+
+      token_store.delete_tokens(slack_user_id)
+    end
+  end
+
+  describe '#authenticated?' do
+    context 'when user has valid tokens' do
+      before do
+        allow(token_store).to receive(:get_tokens).with(slack_user_id).and_return({
+          access_token: 'valid_token',
+          refresh_token: 'refresh_token',
+          expires_at: Time.now.to_i + 1800
+        })
+      end
+
+      it 'returns true' do
+        expect(token_store.authenticated?(slack_user_id)).to be true
+      end
+    end
+
+    context 'when user has no tokens' do
+      before do
+        allow(token_store).to receive(:get_tokens).with(slack_user_id).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(token_store.authenticated?(slack_user_id)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
  - LambdaメモリベースのトークンキャッシュをDynamoDB永続化に変更
  - DynamoDbTokenStoreクラスでトークンのCRUD操作を実装
  - GoogleOAuthClientをメモリキャッシュからDynamoDB使用に更新
  - KMS暗号化とTTL自動削除機能付きDynamoDBテーブルを設定
  - Lambda IAMロールにDynamoDBアクセス権限を追加
  - Gemfileにaws-sdk-dynamodb依存関係を追加
  - DynamoDbTokenStoreの包括的なRSpecテストを作成
  - DynamoDBアーキテクチャ詳細をドキュメントに追加

  インフラ変更:
  - Terraformでoauth_tokensテーブルを作成
  - AWS管理キーでサーバーサイド暗号化を設定
  - トークン自動クリーンアップ用TTLを設定
  - OAUTH_TOKENS_TABLE_NAME環境変数を追加