### PR TITLE
feat: 実行者情報をSlack通知に連携する機能を追加

### DIFF
--- a/analyzer/lambda/spec/lambda_handler_spec.rb
+++ b/analyzer/lambda/spec/lambda_handler_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe LambdaHandler do
         end
 
         it 'Slack通知を送信' do
-          expect(slack_client).to receive(:send_notification).with(summary)
+          expected_summary = summary.dup
+          expected_summary['executor_info'] = { user_id: nil, user_email: nil }
+          expect(slack_client).to receive(:send_notification).with(expected_summary)
           handler.handle(event: event, context: context)
         end
       end


### PR DESCRIPTION
  - lambda_handler.rb: slack_user_id/slack_user_emailの取得と連携
  - integration_service.rb: executor_infoの統合処理を追加
  - テストケース更新

  Fixes #154 (実行者メンション機能)

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>