### PR TITLE
bug: アクセストークンの認証期限が切れていた場合はリフレッシュトークンを利用するように修正した。

### DIFF
--- a/drive-selector/lambda/lib/dynamodb_token_store.rb
+++ b/drive-selector/lambda/lib/dynamodb_token_store.rb
@@ -47,10 +47,8 @@ class DynamoDbTokenStore
 
       token_data = response.item
       
-      # トークンの有効期限を確認（バッファ付き）
-      if token_data['expires_at'] && token_data['expires_at'] < (Time.now.to_i + EXPIRY_BUFFER)
-        return nil
-      end
+      # 期限切れチェックを削除 - GoogleOAuthClientで処理する
+      # 期限切れでもリフレッシュトークンが必要なため、データはそのまま返す
 
       {
         access_token: token_data['access_token'],

--- a/drive-selector/lambda/lib/google_oauth_client.rb
+++ b/drive-selector/lambda/lib/google_oauth_client.rb
@@ -116,7 +116,8 @@ class GoogleOAuthClient
 
   # ユーザーが認証済みかチェック
   def authenticated?(slack_user_id)
-    @token_store.authenticated?(slack_user_id)
+    tokens = get_tokens(slack_user_id)
+    !tokens.nil? && !tokens[:access_token].nil?
   end
 
   # トークンをDynamoDBから削除（ログアウト）

--- a/drive-selector/lambda/spec/lib/dynamodb_token_store_spec.rb
+++ b/drive-selector/lambda/spec/lib/dynamodb_token_store_spec.rb
@@ -143,14 +143,17 @@ RSpec.describe DynamoDbTokenStore do
         })
       end
 
-      it 'returns nil' do
+      it 'returns tokens even when expired (for refresh handling)' do
         expect(mock_dynamodb).to receive(:get_item).with(
           table_name: table_name,
           key: { user_id: slack_user_id }
         ).and_return(dynamodb_response)
 
         result = token_store.get_tokens(slack_user_id)
-        expect(result).to be_nil
+        expect(result).not_to be_nil
+        expect(result[:access_token]).to eq(tokens['access_token'])
+        expect(result[:refresh_token]).to eq(tokens['refresh_token'])
+        expect(result[:expires_at]).to eq(expired_expires_at)
       end
     end
 


### PR DESCRIPTION
動作フロー（修正後）

  ユーザーがSlackでファイル検索
  ↓
  期限切れアクセストークンを検知
  ↓
  リフレッシュトークンで自動更新
  ↓
  新しいアクセストークンでAPI呼び出し
  ↓
  結果をユーザーに返却（認証画面なし）