### PR TITLE
fix: Slackの会議雰囲気メッセージをevidenceからcommentに変更

### DIFF
--- a/analyzer/lambda/lib/slack_message_builder.rb
+++ b/analyzer/lambda/lib/slack_message_builder.rb
@@ -164,11 +164,11 @@ class SlackMessageBuilder
     text_lines = ["*🌡️ 会議の雰囲気*"]
     text_lines << tone_japanese
 
-    # 根拠を最大3件まで表示
-    evidence = atmosphere['evidence'] || []
-    evidence.first(3).each do |item|
-      cleaned_item = item.gsub(/\s*[\(（]\d{1,2}:\d{2}(?::\d{2})?[\)）]\s*/, '')
-      text_lines << "• #{cleaned_item}"
+    # Geminiが生成したコメントを表示
+    comment = atmosphere['comment']
+    if comment && !comment.strip.empty?
+      text_lines << ""
+      text_lines << comment
     end
 
     {

--- a/analyzer/lambda/spec/notion_client_spec.rb
+++ b/analyzer/lambda/spec/notion_client_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe NotionClient do
         },
         'atmosphere' => {
           'overall_tone' => 'positive',
-          'evidence' => ['ポジティブで建設的な雰囲気']
+          'comment' => 'チーム全体が積極的に議論に参加し、特にプロジェクトの方向性について建設的な意見交換が行われました。参加者からの前向きなフィードバックが多く、高いモチベーションが感じられる雰囲気でした。'
         },
         'improvement_suggestions' => [
           {
@@ -249,7 +249,7 @@ RSpec.describe NotionClient do
         },
         'atmosphere' => {
           'overall_tone' => 'positive',
-          'evidence' => ['良好']
+          'comment' => 'チームメンバー全員が会議に集中し、建設的な議論が展開されました。積極的な参加姿勢と協力的な雰囲気が特徴的で、プロジェクトに対する意欲が感じられました。'
         },
         'improvement_suggestions' => [
           { 'category' => 'facilitation', 'suggestion' => 'アドバイス', 'expected_impact' => '改善' }

--- a/analyzer/lambda/spec/slack_client_spec.rb
+++ b/analyzer/lambda/spec/slack_client_spec.rb
@@ -239,10 +239,7 @@ RSpec.describe SlackClient do
           'actions' => [],
           'atmosphere' => {
             'overall_tone' => 'positive',
-            'evidence' => [
-              '素晴らしい進捗ですね',
-              '順調に進んでいます'
-            ]
+            'comment' => 'チーム全体が積極的に議論に参加し、特にリリース計画について建設的な意見交換が行われていました。参加者からの前向きなフィードバックが多く、プロジェクトへの高いモチベーションが感じられる雰囲気でした。'
           },
           'improvement_suggestions' => [
             {


### PR DESCRIPTION
Slackに送信される会議の雰囲気メッセージを改善しました。

## 変更内容

- Geminiプロンプトで100-150文字の具体的なコメント生成機能を追加
- atmosphere.evidenceからatmosphere.commentへスキーマ変更
- SlackMessageBuilderでコメント表示に対応
- 関連テストを新フォーマットに更新

## 期待される効果

- より具体的で読みやすい会議雰囲気メッセージ
- Geminiが生成する自然な日本語コメントで、会議の雰囲気をより効果的に伝達
- 元の発言の引用がなくなることで、メッセージの可読性が向上

Fixes #200

🤖 Generated with [Claude Code](https://claude.ai/code)