### PR TITLE
fix: 長くなるので改善提案は送らない

### DIFF
--- a/analyzer/lambda/lib/slack_message_builder.rb
+++ b/analyzer/lambda/lib/slack_message_builder.rb
@@ -188,7 +188,6 @@ class SlackMessageBuilder
 
     suggestions.each_with_index do |suggestion, index|
       text_lines << "#{index + 1}. #{suggestion['suggestion']}"
-      text_lines << "   → 期待効果: #{suggestion['expected_impact']}" if suggestion['expected_impact']
     end
 
     {


### PR DESCRIPTION
## Summary
- Remove expected_impact display from Slack improvement suggestions section
- Keep API response backward compatibility
- Maintain all existing test cases

## Changes
- Modified `/analyzer/lambda/lib/slack_message_builder.rb:191`
- Removed expected_impact display line from build_suggestions_section method

Closes #204

Generated with [Claude Code](https://claude.ai/code)